### PR TITLE
fix: 외근신청 시 주말 포함 기간에서 평일만 휴가 계산하도록 수정

### DIFF
--- a/notify_worktime_left.py
+++ b/notify_worktime_left.py
@@ -259,14 +259,21 @@ def get_monthly_vacation_breakdown(year: int, month: int, workevent):
             if e_dt < first_day_dt or s_dt > last_day_dt:
                 continue
 
-            total_days = (e_dt - s_dt).days + 1
-            if total_days <= 0:
-                continue
-
-            per_day_fraction = counted / total_days
+            # 평일(월~금)만 계산
+            weekday_count = 0
             dt_cursor = s_dt
             while dt_cursor <= e_dt:
-                if first_day_dt <= dt_cursor <= last_day_dt:
+                if dt_cursor.weekday() < 5:
+                    weekday_count += 1
+                dt_cursor += timedelta(days=1)
+            
+            if weekday_count <= 0:
+                continue
+
+            per_day_fraction = counted / weekday_count
+            dt_cursor = s_dt
+            while dt_cursor <= e_dt:
+                if first_day_dt <= dt_cursor <= last_day_dt and dt_cursor.weekday() < 5:
                     d_num = dt_cursor.day
                     day_to_vac_fraction[d_num] += per_day_fraction
                     if day_to_vac_fraction[d_num] > 1.0:
@@ -325,14 +332,21 @@ def get_daily_vacation_map(year: int, month: int, workevent):
             if e_dt < first_day_dt or s_dt > last_day_dt:
                 continue
 
-            total_days = (e_dt - s_dt).days + 1
-            if total_days <= 0:
-                continue
-
-            per_day_fraction = counted / total_days
+            # 평일(월~금)만 계산
+            weekday_count = 0
             dt_cursor = s_dt
             while dt_cursor <= e_dt:
-                if first_day_dt <= dt_cursor <= last_day_dt:
+                if dt_cursor.weekday() < 5:
+                    weekday_count += 1
+                dt_cursor += timedelta(days=1)
+            
+            if weekday_count <= 0:
+                continue
+
+            per_day_fraction = counted / weekday_count
+            dt_cursor = s_dt
+            while dt_cursor <= e_dt:
+                if first_day_dt <= dt_cursor <= last_day_dt and dt_cursor.weekday() < 5:
                     d_day = dt_cursor.day
                     day_to_vac[d_day] += per_day_fraction
                     if day_to_vac[d_day] > 1.0:

--- a/test_vacation_calculation.py
+++ b/test_vacation_calculation.py
@@ -1,0 +1,113 @@
+"""
+휴가 계산 로직 테스트
+주말 포함 외근신청 시 평일만 계산되는지 검증
+"""
+
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+
+from notify_worktime_left import get_monthly_vacation_breakdown, get_daily_vacation_map
+
+
+class TestVacationCalculation(unittest.TestCase):
+    """휴가 계산 로직 테스트"""
+
+    def test_weekend_vacation_calculation(self):
+        """주말 포함 휴가 신청 시 평일만 계산되는지 테스트"""
+        # 2025년 1월 3일(금) ~ 6일(월) 2일 휴가 신청
+        mock_workevent = {
+            "results": [
+                {
+                    "wk_start_date": "2025-01-03",  # 금요일
+                    "wk_end_date": "2025-01-06",    # 월요일
+                    "wk_counted_days": 2.0,         # 2일 휴가
+                }
+            ]
+        }
+        
+        # 1월 3일이 금요일인 2025년 1월 테스트
+        result = get_monthly_vacation_breakdown(2025, 1, mock_workevent)
+        
+        # 금요일 1일 + 월요일 1일 = 2일만 계산되어야 함
+        self.assertEqual(result["used_days"], 2.0, "주말 포함 휴가에서 평일만 계산되어야 함")
+
+    def test_daily_vacation_map_weekend(self):
+        """일별 휴가 맵에서 주말 제외 확인"""
+        mock_workevent = {
+            "results": [
+                {
+                    "wk_start_date": "2025-01-03",  # 금요일
+                    "wk_end_date": "2025-01-06",    # 월요일
+                    "wk_counted_days": 2.0,
+                }
+            ]
+        }
+        
+        daily_map = get_daily_vacation_map(2025, 1, mock_workevent)
+        
+        # 3일(금): 1.0, 4일(토): 0.0, 5일(일): 0.0, 6일(월): 1.0
+        self.assertEqual(daily_map[3], 1.0, "금요일은 1일 휴가")
+        self.assertEqual(daily_map[4], 0.0, "토요일은 휴가 없음")
+        self.assertEqual(daily_map[5], 0.0, "일요일은 휴가 없음")
+        self.assertEqual(daily_map[6], 1.0, "월요일은 1일 휴가")
+
+    def test_weekday_only_vacation(self):
+        """평일만 휴가 신청 시 정상 동작 확인"""
+        mock_workevent = {
+            "results": [
+                {
+                    "wk_start_date": "2025-01-07",  # 화요일
+                    "wk_end_date": "2025-01-09",    # 목요일
+                    "wk_counted_days": 3.0,
+                }
+            ]
+        }
+        
+        result = get_monthly_vacation_breakdown(2025, 1, mock_workevent)
+        self.assertEqual(result["used_days"], 3.0, "평일만 휴가 시 정상 계산")
+
+    def test_partial_vacation_with_weekend(self):
+        """반차 포함 주말 휴가 테스트"""
+        mock_workevent = {
+            "results": [
+                {
+                    "wk_start_date": "2025-01-03",  # 금요일
+                    "wk_end_date": "2025-01-06",    # 월요일
+                    "wk_counted_days": 1.0,         # 1일 휴가 (반차 2개)
+                }
+            ]
+        }
+        
+        daily_map = get_daily_vacation_map(2025, 1, mock_workevent)
+        
+        # 1일 휴가를 2개 평일로 나누면 각각 0.5일
+        self.assertEqual(daily_map[3], 0.5, "금요일 반차")
+        self.assertEqual(daily_map[4], 0.0, "토요일 휴가 없음")
+        self.assertEqual(daily_map[5], 0.0, "일요일 휴가 없음")
+        self.assertEqual(daily_map[6], 0.5, "월요일 반차")
+
+    def test_weekend_only_vacation(self):
+        """주말만 휴가 신청 시 (실제로는 발생하지 않지만 방어적 테스트)"""
+        mock_workevent = {
+            "results": [
+                {
+                    "wk_start_date": "2025-01-04",  # 토요일
+                    "wk_end_date": "2025-01-05",    # 일요일
+                    "wk_counted_days": 2.0,
+                }
+            ]
+        }
+        
+        result = get_monthly_vacation_breakdown(2025, 1, mock_workevent)
+        daily_map = get_daily_vacation_map(2025, 1, mock_workevent)
+        
+        # 평일이 없으므로 휴가 적용 안됨
+        self.assertEqual(result["used_days"], 0.0, "주말만 신청 시 휴가 없음")
+        self.assertEqual(daily_map[4], 0.0, "토요일 휴가 없음")
+        self.assertEqual(daily_map[5], 0.0, "일요일 휴가 없음")
+
+
+if __name__ == "__main__":
+    # 테스트 실행
+    unittest.main()


### PR DESCRIPTION
## Summary
- 금~월 외근신청 시 주말까지 휴가로 계산되던 오작동 수정
- 휴가 계산 로직에서 평일(월~금)만 계산하도록 변경
- 주말 포함 외근신청 검증을 위한 테스트 코드 추가

## Test plan
- [x] 기존 테스트 통과 확인
- [x] 새로운 테스트 케이스 작성 및 실행
- [x] 금~월 휴가 신청 시 2일만 차감되는지 검증
- [ ] 실제 환경에서 notify_worktime_left 스크립트 동작 확인

🤖 Generated with [Claude Code](https://claude.ai/code)