### PR TITLE
feat: repo별 추가 ruleset 지원 (TASK-5371)

### DIFF
--- a/scripts/github/add_ruleset.py
+++ b/scripts/github/add_ruleset.py
@@ -103,7 +103,7 @@ def load_repo_rulesets_config() -> dict[str, dict]:
         {
           "repo-name": {
             "add": ["추가_ruleset.json"],   # repo에 추가 적용할 ruleset 파일 목록
-            "skip": ["main"]                # org 전체 적용에서 제외할 ruleset 키 목록
+            "skip": ["ruleset.json"]        # org 전체 적용에서 제외할 ruleset 파일 목록
           }
         }
 
@@ -370,15 +370,16 @@ def main():
     total_success = 0
     total_error = 0
 
-    # repo별 config에서 skip 목록 구성
+    # repo별 config에서 skip 목록 구성 (파일명 → 제외할 repo 집합)
     repo_config = load_repo_rulesets_config()
-    skip_repos_by_key: dict[str, set[str]] = {}
+    skip_repos_by_file: dict[str, set[str]] = {}
     for repo_name, conf in repo_config.items():
-        for key in conf.get("skip", []):
-            skip_repos_by_key.setdefault(key, set()).add(repo_name)
+        for ruleset_file in conf.get("skip", []):
+            skip_repos_by_file.setdefault(ruleset_file, set()).add(repo_name)
 
     # 1단계: org 전체 ruleset 적용
     for ruleset_key, ruleset_template in ruleset_templates:
+        ruleset_file = AVAILABLE_RULESETS[ruleset_key]
         ruleset_name = ruleset_template["name"]
         print(f"\n[Ruleset: {ruleset_name}]")
         print("-" * 50)
@@ -389,7 +390,7 @@ def main():
             ruleset_key,
             ruleset_template,
             args.dry_run,
-            skip_repos=skip_repos_by_key.get(ruleset_key),
+            skip_repos=skip_repos_by_file.get(ruleset_file),
         )
         total_success += success
         total_error += error

--- a/scripts/github/add_ruleset.py
+++ b/scripts/github/add_ruleset.py
@@ -100,10 +100,7 @@ def load_repo_rulesets_config() -> dict[str, list[str]]:
     repo별 추가 ruleset 매핑 설정을 로드하는 함수
 
     Returns:
-        dict: repo 이름 → ruleset 파일 목록 매핑
-
-    Raises:
-        FileNotFoundError: 설정 파일이 없는 경우
+        dict: repo 이름 → ruleset 파일 목록 매핑 (설정 파일이 없으면 빈 딕셔너리)
     """
     config_path = SCRIPT_DIR / REPO_RULESETS_CONFIG_FILE
     if not config_path.exists():
@@ -268,12 +265,11 @@ def apply_ruleset_to_repos(
     return success_count, error_count
 
 
-def apply_repo_specific_rulesets(org, org_name: str, dry_run: bool) -> tuple[int, int]:
+def apply_repo_specific_rulesets(org_name: str, dry_run: bool) -> tuple[int, int]:
     """
     repo_rulesets_config.json에 정의된 repo별 추가 ruleset을 적용하는 함수
 
     Args:
-        org: PyGithub Organization 객체
         org_name: Organization 이름
         dry_run: dry-run 모드 여부
 
@@ -372,7 +368,7 @@ def main():
     print("repo별 추가 Ruleset 적용")
     print("=" * 60)
 
-    repo_success, repo_error = apply_repo_specific_rulesets(org, org_name, args.dry_run)
+    repo_success, repo_error = apply_repo_specific_rulesets(org_name, args.dry_run)
     total_success += repo_success
     total_error += repo_error
 

--- a/scripts/github/repo_rulesets_config.json
+++ b/scripts/github/repo_rulesets_config.json
@@ -4,5 +4,8 @@
   },
   "tmn-e2e-video": {
     "skip": ["ruleset.json"]
+  },
+  "tmn-cc-settings": {
+    "skip": ["ruleset.json"]
   }
 }

--- a/scripts/github/repo_rulesets_config.json
+++ b/scripts/github/repo_rulesets_config.json
@@ -1,0 +1,3 @@
+{
+  "jce-codle-react": ["ruleset_develop_fe_only.json"]
+}

--- a/scripts/github/repo_rulesets_config.json
+++ b/scripts/github/repo_rulesets_config.json
@@ -1,3 +1,8 @@
 {
-  "jce-codle-react": ["ruleset_develop_fe_only.json"]
+  "jce-codle-react": {
+    "add": ["ruleset_develop_fe_only.json"]
+  },
+  "tmn-e2e-video": {
+    "skip": ["main"]
+  }
 }

--- a/scripts/github/repo_rulesets_config.json
+++ b/scripts/github/repo_rulesets_config.json
@@ -3,6 +3,6 @@
     "add": ["ruleset_develop_fe_only.json"]
   },
   "tmn-e2e-video": {
-    "skip": ["main"]
+    "skip": ["ruleset.json"]
   }
 }

--- a/scripts/github/ruleset_develop_fe_only.json
+++ b/scripts/github/ruleset_develop_fe_only.json
@@ -1,0 +1,42 @@
+{
+  "name": "Develop FE Only Push",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/develop"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 16248219,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 10349524,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
## 배경

타 전문 분야 간 develop 브랜치 공유 사용으로 충돌 증가. jce-codle-react의 develop 브랜치에 FE 팀만 직접 push 가능하도록 ruleset 추가하고, 특정 repo를 org 전체 ruleset에서 제외할 수 있도록 지원.

## 변경사항

- `repo_rulesets_config.json`: repo별 ruleset 설정 파일 신규 생성
  - `add`: repo에 추가 적용할 ruleset 파일 목록
  - `skip`: org 전체 적용에서 제외할 ruleset 파일 목록
  - jce-codle-react: develop FE only ruleset 추가 적용
  - tmn-e2e-video: main protection ruleset 제외 (누구나 main push 가능)
- `ruleset_develop_fe_only.json`: develop 브랜치 PR 필수 규칙 (bypass: frontend 팀, security 팀, org admin)
- `add_ruleset.py`: org 전체 ruleset 적용 후, config에 따라 repo별 추가/제외 처리하는 2단계 실행 구조
  - `apply_ruleset_to_repo()`: 단일 repo 적용 로직 추출
  - `apply_repo_specific_rulesets()`: config의 `add` 기반 repo별 추가 적용
  - `apply_ruleset_to_repos()`: config의 `skip` 기반 repo별 제외 처리
  - `load_repo_rulesets_config()`: config 파일 로드

## 검증

- `black --check` 통과
- Python AST 파싱 통과
- JSON 파일 로드/파싱 정상 확인
- skip 로직 검증: `tmn-e2e-video`가 `ruleset.json`에서 제외됨 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)