### PR TITLE
feat: Justin 봇 — 미팅 보고서/제안서 자동 피드백

### DIFF
--- a/app/justin.py
+++ b/app/justin.py
@@ -27,7 +27,7 @@ from .tool_status_handler import ToolStatusHandler
 
 KST = ZoneInfo("Asia/Seoul")
 
-MODEL = "claude-opus-4-20250514"
+MODEL = "claude-opus-4-6"
 
 # Justin 프롬프트 MD 파일 캐시
 _prompts_cache: dict[str, str] = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,5 +29,4 @@ pydantic
 boto3
 pandas
 matplotlib
-pdf2image
-Pillow
+anthropic


### PR DESCRIPTION
## Summary
- Slack에서 `@Justin` 멘션 + Notion 링크 또는 PDF 첨부 시 자동 피드백 생성
- 미팅 보고서: Notion 페이지 → 마크다운 변환 → Claude Opus 4.6 피드백
- 제안서: PDF 첨부 → Claude 네이티브 PDF API (텍스트+시각 듀얼 분석) → 피드백
- 4번째 Slack Bot으로 `asyncio.gather`에 등록 (기존 3개 봇과 동시 운영)

## 변경 파일
| 파일 | 설명 |
|------|------|
| `app/justin.py` | Justin 봇 핸들러 (Notion 파싱, PDF 분석, 문서 유형 감지, 피드백 생성) |
| `app.py` | Justin 봇을 4번째 concurrent bot으로 등록 |
| `.env.example` | Justin 토큰 환경변수 추가 |
| `requirements.txt` | `anthropic` SDK 추가 |
| `justin_prompts/*.md` | 피드백 프롬프트 3개 (meeting_feedback, proposal_feedback, proposal_review_page_by_page) |

## 주요 설계 결정
- **LLM**: Claude Opus 4.6 (`claude-opus-4-20250514`)
- **PDF 처리**: Anthropic 네이티브 PDF API (`type: "document"`) — pdf2image/poppler 의존성 없음
- **프롬프트 경로**: `justin_prompts/` 하드코딩 (환경변수 미사용)
- **프롬프트 익명화**: 개인 이름 제거, 리드/팀원 역할 기반으로만 구분

## Test plan
- [ ] `.env`에 `SLACK_BOT_TOKEN_JUSTIN`, `SLACK_APP_TOKEN_JUSTIN`, `ANTHROPIC_API_KEY` 설정
- [ ] `python app.py` → 4개 봇 동시 기동 확인
- [ ] Slack에서 `@Justin` + Notion 링크 → 미팅 보고서 피드백 응답 확인
- [ ] Slack에서 `@Justin` + PDF 첨부 → 제안서 피드백 응답 확인
- [ ] 문서 유형 자동 감지 (미팅/제안서) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)