### PR TITLE
fix: notion2md 토글 블록 인덴테이션 오류 수정

### DIFF
--- a/app/common.py
+++ b/app/common.py
@@ -14,7 +14,7 @@ from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 from dotenv import load_dotenv
 from notion_client import Client as NotionClient
-from notion2md.exporter.block import StringExporter
+from notion_to_md import NotionToMarkdown
 from langchain_core.tools import tool
 from langchain_community.document_loaders import WebBaseLoader
 from langchain_community.tools import TavilySearchResults
@@ -499,7 +499,10 @@ def get_notion_page_tool():
         노션 페이지를 마크다운 형태로 조회합니다.
         www.notion.so 에 대한 링크는 반드시 이 도구를 사용하여 조회합니다.
         """
-        return StringExporter(block_id=page_id, output_path="test").export()
+        n2m = NotionToMarkdown(notion_client=notion)
+        md_blocks = n2m.page_to_markdown(page_id)
+        md_string_dict = n2m.to_markdown_string(md_blocks)
+        return md_string_dict.get("parent", "")
 
     return get_notion_page
 

--- a/app/common.py
+++ b/app/common.py
@@ -118,6 +118,15 @@ KST = ZoneInfo("Asia/Seoul")
 # 노션 클라이언트 초기화
 notion = NotionClient(auth=os.environ.get("NOTION_TOKEN"))
 
+
+def notion_page_to_markdown(page_id: str) -> str:
+    """노션 페이지를 마크다운 문자열로 변환한다."""
+    n2m = NotionToMarkdown(notion_client=notion)
+    md_blocks = n2m.page_to_markdown(page_id)
+    md_string_dict = n2m.to_markdown_string(md_blocks)
+    return md_string_dict.get("parent", "")
+
+
 _cache_slack_users = TTLCache(maxsize=100, ttl=3600)
 _cache_notion_users = TTLCache(maxsize=100, ttl=3600)
 _cache_database_schema = TTLCache(maxsize=10, ttl=3600)
@@ -499,10 +508,7 @@ def get_notion_page_tool():
         노션 페이지를 마크다운 형태로 조회합니다.
         www.notion.so 에 대한 링크는 반드시 이 도구를 사용하여 조회합니다.
         """
-        n2m = NotionToMarkdown(notion_client=notion)
-        md_blocks = n2m.page_to_markdown(page_id)
-        md_string_dict = n2m.to_markdown_string(md_blocks)
-        return md_string_dict.get("parent", "")
+        return notion_page_to_markdown(page_id)
 
     return get_notion_page
 

--- a/app/justin.py
+++ b/app/justin.py
@@ -20,9 +20,9 @@ import aiohttp
 import anthropic
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import SystemMessage, HumanMessage
-from notion2md.exporter.block import StringExporter
+from notion_to_md import NotionToMarkdown
 
-from .common import slack_users_list
+from .common import slack_users_list, notion
 from .tool_status_handler import ToolStatusHandler
 
 KST = ZoneInfo("Asia/Seoul")
@@ -223,7 +223,10 @@ async def _handle_notion_feedback(
     )
 
     try:
-        page_content = StringExporter(block_id=page_id, output_path="test").export()
+        n2m = NotionToMarkdown(notion_client=notion)
+        md_blocks = n2m.page_to_markdown(page_id)
+        md_string_dict = n2m.to_markdown_string(md_blocks)
+        page_content = md_string_dict.get("parent", "")
     except Exception as e:
         await say(
             f"Notion 페이지를 읽는 데 실패했습니다. 페이지 ID를 확인해주세요.\n"

--- a/app/justin.py
+++ b/app/justin.py
@@ -20,9 +20,7 @@ import aiohttp
 import anthropic
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import SystemMessage, HumanMessage
-from notion_to_md import NotionToMarkdown
-
-from .common import slack_users_list, notion
+from .common import slack_users_list, notion_page_to_markdown
 from .tool_status_handler import ToolStatusHandler
 
 KST = ZoneInfo("Asia/Seoul")
@@ -223,10 +221,7 @@ async def _handle_notion_feedback(
     )
 
     try:
-        n2m = NotionToMarkdown(notion_client=notion)
-        md_blocks = n2m.page_to_markdown(page_id)
-        md_string_dict = n2m.to_markdown_string(md_blocks)
-        page_content = md_string_dict.get("parent", "")
+        page_content = notion_page_to_markdown(page_id)
     except Exception as e:
         await say(
             f"Notion 페이지를 읽는 데 실패했습니다. 페이지 ID를 확인해주세요.\n"

--- a/main.py
+++ b/main.py
@@ -15,8 +15,7 @@ from fastapi import FastAPI, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 import uvicorn
-from notion_to_md import NotionToMarkdown
-from notion_client import Client as NotionClient
+from app.common import notion_page_to_markdown
 from github import Github, GithubException
 from dotenv import load_dotenv
 
@@ -124,15 +123,9 @@ def extract_title(properties: dict) -> str:
     return "Untitled"
 
 
-_notion_client = NotionClient(auth=os.environ.get("NOTION_TOKEN"))
-
-
 def get_notion_markdown(page_id: str) -> str:
     """Notion 페이지를 마크다운으로 변환"""
-    n2m = NotionToMarkdown(notion_client=_notion_client)
-    md_blocks = n2m.page_to_markdown(page_id)
-    md_string_dict = n2m.to_markdown_string(md_blocks)
-    return md_string_dict.get("parent", "")
+    return notion_page_to_markdown(page_id)
 
 
 def create_branch_name(task_id: str) -> str:

--- a/main.py
+++ b/main.py
@@ -15,7 +15,8 @@ from fastapi import FastAPI, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 import uvicorn
-from notion2md.exporter.block import StringExporter
+from notion_to_md import NotionToMarkdown
+from notion_client import Client as NotionClient
 from github import Github, GithubException
 from dotenv import load_dotenv
 
@@ -123,9 +124,15 @@ def extract_title(properties: dict) -> str:
     return "Untitled"
 
 
+_notion_client = NotionClient(auth=os.environ.get("NOTION_TOKEN"))
+
+
 def get_notion_markdown(page_id: str) -> str:
     """Notion 페이지를 마크다운으로 변환"""
-    return StringExporter(block_id=page_id, output_path="dummy").export()
+    n2m = NotionToMarkdown(notion_client=_notion_client)
+    md_blocks = n2m.page_to_markdown(page_id)
+    md_string_dict = n2m.to_markdown_string(md_blocks)
+    return md_string_dict.get("parent", "")
 
 
 def create_branch_name(task_id: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ notion-client==2.7.0
 md2notionpage
 cachetools
 requests
-notion2md
+notion-to-md-py @ git+https://github.com/team-monolith-product/notion-to-md-py.git@main
 langchain-community
 langchain-openai
 langchain-anthropic


### PR DESCRIPTION
## 배경

노션 페이지를 Markdown으로 변환할 때 `notion2md` 라이브러리가 토글 블록의 children을 탭 문자(`\t`)로 인덴트하여 CommonMark 파서에서 indented code block으로 해석되는 문제가 있었습니다.

## 변경사항

- `notion2md` → `notion-to-md-py` (team-monolith-product 포크)로 교체
  - 포크에서 `add_tab_space()` 함수의 `\t` → 4-space 인덴트로 수정 (JS upstream 커밋 `7af0f46c` 반영)
  - `toggle()` 함수를 multiline `<details>` 형식으로 수정
- `app/common.py`: `get_notion_page_tool()` API 교체
- `app/justin.py`: `_handle_notion_feedback()` API 교체
- `main.py`: `get_notion_markdown()` API 교체
- `requirements.txt`: 의존성 교체

## upstream PR

- https://github.com/SwordAndTea/notion-to-md-py/pull/9
- upstream 머지 시 공식 PyPI 패키지로 전환 가능

## 검증

- notion-to-md-py 포크: 34개 테스트 전체 통과
- workflow-automation: `black .` 포맷 통과, 기존 테스트 중 본 변경과 무관한 실패만 존재