### PR TITLE
fix: Dockerfile에 git 추가 (pip git+https 의존성)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app
 # 한글 폰트 설치 (matplotlib 차트 한글 표시용)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-nanum \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # matplotlib 폰트 캐시 삭제 (새 폰트 인식을 위해)


### PR DESCRIPTION
## 배경

PR #33에서 `notion2md` → `notion-to-md-py` 포크로 교체하면서 `requirements.txt`에 `git+https://` URL이 추가되었으나, Docker 이미지(`python:3.11-slim`)에 `git`이 없어 빌드가 실패했습니다.

- 실패 빌드: https://github.com/team-monolith-product/tmn-workflow-automation/actions/runs/22333011179

## 변경사항

- `Dockerfile`: `apt-get install`에 `git` 추가