### PR TITLE
feat: 고객팀 보고서 검증 워크플로우 추가 (TASK-5381)

### DIFF
--- a/.github/workflows/validate_customer_reports.yaml
+++ b/.github/workflows/validate_customer_reports.yaml
@@ -1,0 +1,27 @@
+
+name: Validate Customer Reports
+
+on:
+  schedule:
+    - cron: '45 23 * * 0-4'  # 평일 08:45 KST (UTC+9)
+  workflow_dispatch:
+
+jobs:
+  validate_customer_reports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run validate_customer_reports.py
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          SLACK_BOT_TOKEN_JUSTIN: ${{ secrets.SLACK_BOT_TOKEN_JUSTIN }}
+        run: |
+          python scripts/validate_customer_reports.py

--- a/scripts/validate_customer_reports.py
+++ b/scripts/validate_customer_reports.py
@@ -28,7 +28,30 @@ def main(dry_run: bool = False):
 
     email_to_user_id = get_email_to_user_id(slack_client)
 
-    alert_missing_author(notion, slack_client, email_to_user_id, dry_run)
+    send_intro_message(slack_client, dry_run)
+    issues_found = alert_missing_author(notion, slack_client, email_to_user_id, dry_run)
+
+    if not issues_found:
+        text = "검출된 항목이 없습니다. 고생하셨습니다!"
+        if dry_run:
+            print(f"[dry-run] {text}")
+        else:
+            slack_client.chat_postMessage(channel=CHANNEL_ID, text=text)
+
+
+def send_intro_message(
+    slack_client: WebClient,
+    dry_run: bool = False,
+):
+    """일간 고객팀 보고서 자동 검수 인트로 메시지 전송"""
+    text = (
+        "일간 고객팀 보고서 자동 검수 결과를 안내드립니다.\n"
+        "아래 항목을 확인 후 조치 부탁드립니다."
+    )
+    if dry_run:
+        print(f"[dry-run] {text}")
+    else:
+        slack_client.chat_postMessage(channel=CHANNEL_ID, text=text)
 
 
 def alert_missing_author(
@@ -88,6 +111,8 @@ def alert_missing_author(
             print(f"[dry-run] {text}")
         else:
             slack_client.chat_postMessage(channel=CHANNEL_ID, text=text)
+
+    return len(results.get("results", [])) > 0
 
 
 if __name__ == "__main__":

--- a/scripts/validate_customer_reports.py
+++ b/scripts/validate_customer_reports.py
@@ -1,0 +1,102 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import argparse
+import os
+
+from dotenv import load_dotenv
+from notion_client import Client as NotionClient
+from slack_sdk import WebClient
+
+from service.slack import get_email_to_user_id
+
+# 환경 변수 로드
+load_dotenv()
+
+DATA_SOURCE_ID: str = "2ae51eb0-a108-435f-95aa-802aaab6812f"
+CHANNEL_ID: str = "C0AH3KVLPLH"
+CREATED_AFTER: str = "2026-02-24T00:00:00.000Z"
+
+
+def main(dry_run: bool = False):
+    notion = NotionClient(
+        auth=os.environ.get("NOTION_TOKEN"), notion_version="2025-09-03"
+    )
+    slack_client = WebClient(token=os.environ.get("SLACK_BOT_TOKEN_JUSTIN"))
+
+    email_to_user_id = get_email_to_user_id(slack_client)
+
+    alert_missing_author(notion, slack_client, email_to_user_id, dry_run)
+
+
+def alert_missing_author(
+    notion: NotionClient,
+    slack_client: WebClient,
+    email_to_user_id: dict[str, str],
+    dry_run: bool = False,
+):
+    """
+    작성자가 비어있는 보고서를 찾아 생성자에게 작성자 입력을 요청
+
+    Args:
+        notion (NotionClient): Notion 클라이언트
+        slack_client (WebClient): Slack 클라이언트
+        email_to_user_id (dict[str, str]): 이메일 → Slack ID 매핑
+        dry_run (bool): True이면 Slack 전송 없이 콘솔 출력만
+    """
+    results = notion.data_sources.query(
+        **{
+            "data_source_id": DATA_SOURCE_ID,
+            "filter": {
+                "and": [
+                    {
+                        "property": "작성 일시",
+                        "created_time": {"on_or_after": CREATED_AFTER},
+                    },
+                    {"property": "작성자", "people": {"is_empty": True}},
+                ]
+            },
+        }
+    )
+
+    for result in results.get("results", []):
+        try:
+            title = result["properties"]["Name"]["title"][0]["text"]["content"]
+        except (KeyError, IndexError):
+            title = "제목 없음"
+
+        page_url = result["url"]
+
+        created_by = result["properties"]["생성자"]["created_by"]
+        creator_email = created_by["person"]["email"]
+        creator_name = created_by.get("name", creator_email)
+        slack_user_id = email_to_user_id.get(creator_email)
+
+        if slack_user_id:
+            mention = f"<@{slack_user_id}>"
+        else:
+            mention = creator_name
+
+        text = (
+            f"<{page_url}|{title}> 보고서에 작성자가 입력되지 않았습니다. "
+            f"{mention} 작성자를 입력해주세요."
+        )
+
+        if dry_run:
+            print(f"[dry-run] {text}")
+        else:
+            slack_client.chat_postMessage(channel=CHANNEL_ID, text=text)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Slack 메시지를 보내지 않고 콘솔에 출력만",
+    )
+    args = parser.parse_args()
+
+    main(dry_run=args.dry_run)


### PR DESCRIPTION
## 배경

고객팀의 "✏️ 고객팀 보고서" Notion DB에 대해 데이터 품질을 검증하는 주기적 루틴을 추가한다.
기존 `manage_tasks_daily.py`와 유사한 패턴으로, Justin 봇이 Slack 채널에 검증 결과를 알려주는 구조.

## 변경 사항

- `scripts/validate_customer_reports.py`: 고객팀 보고서 검증 스크립트
  - 작성자(`작성자` people 속성)가 비어있는 보고서를 검출
  - 생성자(`생성자` created_by)의 이메일로 Slack ID를 매핑하여 멘션
  - `--dry-run` 플래그로 로컬 테스트 지원
- `.github/workflows/validate_customer_reports.yaml`: 평일 08:45 KST 스케줄 워크플로우

## 검증

- [x] `--dry-run` 실행하여 Notion 쿼리 및 Slack 멘션 매핑 정상 확인
- [x] 실제 실행(wet run)하여 Slack 채널에 메시지 및 멘션 정상 전송 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)