### PR TITLE
fix: Contents DB 시작일 속성 누락으로 인한 daily workflow 크래시 수정

### DIFF
--- a/scripts/manage_tasks_daily.py
+++ b/scripts/manage_tasks_daily.py
@@ -100,13 +100,7 @@ def main():
         CONTENTS_CHANNEL_ID,
         email_to_user_id,
     )
-    alert_pending_but_started_tasks(
-        notion,
-        slack_client,
-        CONTENTS_DATA_SOURCE_ID,
-        CONTENTS_CHANNEL_ID,
-        email_to_user_id,
-    )
+    # 콘텐츠 DB에는 '시작일' formula 속성이 없으므로 alert_pending_but_started_tasks 생략
     alert_no_due_tasks(
         notion,
         slack_client,


### PR DESCRIPTION
## Summary
- 콘텐츠 DB(`fecd7fca`)에는 `시작일` formula 속성이 존재하지 않아, `alert_pending_but_started_tasks` 호출 시 `Could not find property with name or id: 시작일` 에러로 매일 크래시 발생
- 해당 DB에 대한 `alert_pending_but_started_tasks` 호출을 제거하여 **2주 이상 지속된 `manage_tasks_daily` workflow 실패 해결**

## Test plan
- [x] `feature/justin-feedback-bot` 브랜치에서 수동 실행 성공 확인 완료 (run #22380300823)
- [ ] 머지 후 다음 스케줄 실행(KST 08:45)에서 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)