### PR TITLE
fix: shell injection in mcp-memory and infra improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,7 @@ GITHUB_ORG_NAME=your-organization-name
 # Justin Bot Configuration (미팅 보고서/제안서 자동 피드백)
 SLACK_BOT_TOKEN_JUSTIN=xoxb-your-justin-bot-token
 SLACK_APP_TOKEN_JUSTIN=xapp-your-justin-app-token
+
+# AHA Agent Configuration
+# Slack channel for AHA cron/manual run reports (default: C0AHU2XDBT2)
+AHA_REPORT_CHANNEL=C0AHU2XDBT2

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ backup_*.json
 **/.claude/settings.local.json
 
 .idea
+
+# mcp-memory build artifacts
+node_modules/
+mcp-memory/dist/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+set -e
+
+# Claude OAuth
+if [ -n "$CLAUDE_CREDS" ]; then
+    echo "$CLAUDE_CREDS" > /home/agent/.claude/.credentials.json
+fi
+
+# gh CLI
+if [ -n "$GITHUB_TOKEN" ]; then
+    echo "$GITHUB_TOKEN" | gh auth login --with-token 2>/dev/null || true
+fi
+
+# aha-memory clone
+MEMORY_REPO="https://${GITHUB_TOKEN}@github.com/team-monolith-product/aha-memory.git"
+MEMORY_PATH="/home/agent/aha-memory"
+for i in 1 2 3; do
+    git clone "$MEMORY_REPO" "$MEMORY_PATH" 2>/dev/null && break
+    echo "[aha] git clone attempt $i failed, retrying..." >&2
+    sleep 2
+done
+
+# git user config (memory MCP commit용)
+git -C "$MEMORY_PATH" config user.name "aha"
+git -C "$MEMORY_PATH" config user.email "aha@team-monolith.com"
+
+# 실행 맥락 구성
+TRIGGER="${AHA_TRIGGER:-manual}"
+CHANNEL="${AHA_CHANNEL}"
+THREAD_TS="${AHA_THREAD_TS}"
+REPORT_CHANNEL="${AHA_REPORT_CHANNEL:-C0AHU2XDBT2}"
+
+CONTEXT=""
+case "$TRIGGER" in
+    cron)
+        CONTEXT="You were triggered by a scheduled cron job.
+Report your results to Slack channel ${REPORT_CHANNEL} when done."
+        ;;
+    slack)
+        CONTEXT="You were triggered by a Slack mention.
+Reply to the thread: channel=${CHANNEL}, thread_ts=${THREAD_TS}."
+        ;;
+    *)
+        CONTEXT="You were triggered manually.
+Report your results to Slack channel ${REPORT_CHANNEL} when done."
+        ;;
+esac
+
+# system prompt 조립
+APPEND="
+## Trigger Context
+
+${CONTEXT}"
+
+if [ -s "$MEMORY_PATH/MEMORY.md" ]; then
+    APPEND="${APPEND}
+
+## Procedural Memory (from /home/agent/aha-memory/MEMORY.md)
+
+$(cat "$MEMORY_PATH/MEMORY.md")"
+fi
+
+# MCP 설정
+MCP_CONFIG='{
+  "mcpServers": {
+    "notion": { "command": "notion-mcp-server", "args": [], "env": {} },
+    "slack": { "command": "mcp-server-slack", "args": [], "env": {} },
+    "memory": { "command": "node", "args": ["/opt/mcp-memory/dist/index.js"], "env": { "MEMORY_REPO_PATH": "/home/agent/aha-memory" } }
+  }
+}'
+
+# permissions
+cat > /home/agent/.claude/settings.json << 'SETTINGS'
+{
+  "permissions": {
+    "allow": [
+      "mcp__notion__API-post-search",
+      "mcp__notion__API-retrieve-a-page",
+      "mcp__notion__API-patch-page",
+      "mcp__notion__API-post-page",
+      "mcp__notion__API-retrieve-a-page-property",
+      "mcp__notion__API-query-data-source",
+      "mcp__notion__API-retrieve-a-data-source",
+      "mcp__notion__API-retrieve-a-database",
+      "mcp__notion__API-get-block-children",
+      "mcp__notion__API-patch-block-children",
+      "mcp__notion__API-retrieve-a-block",
+      "mcp__notion__API-update-a-block",
+      "mcp__slack__slack_get_channel_history",
+      "mcp__slack__slack_get_thread_replies",
+      "mcp__slack__slack_list_channels",
+      "mcp__slack__slack_post_message",
+      "mcp__slack__slack_reply_to_thread",
+      "mcp__slack__slack_add_reaction",
+      "mcp__memory__memory_update"
+    ],
+    "deny": [
+      "mcp__notion__API-get-user",
+      "mcp__notion__API-get-users",
+      "mcp__notion__API-get-self",
+      "mcp__notion__API-delete-a-block",
+      "mcp__notion__API-create-a-comment",
+      "mcp__notion__API-retrieve-a-comment",
+      "mcp__notion__API-update-a-data-source",
+      "mcp__notion__API-create-a-data-source",
+      "mcp__notion__API-list-data-source-templates",
+      "mcp__notion__API-move-page",
+      "mcp__slack__slack_get_users",
+      "mcp__slack__slack_get_user_profile"
+    ],
+    "defaultMode": "bypassPermissions"
+  }
+}
+SETTINGS
+
+TASK="${1:-시스템 상태를 점검하고 이상 유무를 보고하세요.}"
+
+claude -p "$TASK" \
+    --dangerously-skip-permissions \
+    --mcp-config "$MCP_CONFIG" \
+    --append-system-prompt "$APPEND" \
+    --output-format json \
+    || EXIT_CODE=$?
+
+# 세션 로그를 /sessions 로 복사 (호스트 마운트용)
+if [ -d /sessions ]; then
+    cp /home/agent/.claude/projects/*/*.jsonl /sessions/ 2>/dev/null || true
+    chmod a+r /sessions/*.jsonl 2>/dev/null || true
+fi
+
+exit ${EXIT_CODE:-0}

--- a/mcp-memory/package.json
+++ b/mcp-memory/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "aha-mcp-memory",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "aha-mcp-memory": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "typescript": "^5"
+  }
+}

--- a/mcp-memory/src/index.ts
+++ b/mcp-memory/src/index.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { readFileSync, writeFileSync } from "fs";
+import { execFileSync } from "child_process";
+import { join } from "path";
+
+const CHAR_LIMIT = 5000;
+const REPO_PATH = process.env.MEMORY_REPO_PATH;
+const MEMORY_FILE = "MEMORY.md";
+
+if (!REPO_PATH) {
+  console.error("MEMORY_REPO_PATH is required");
+  process.exit(1);
+}
+
+const filePath = join(REPO_PATH, MEMORY_FILE);
+
+function git(...args: string[]): string {
+  return execFileSync("git", ["-C", REPO_PATH!, ...args], { encoding: "utf-8" }).trim();
+}
+
+function readMemory(): string {
+  try {
+    return readFileSync(filePath, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+const server = new Server(
+  { name: "aha-memory", version: "0.1.0" },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "memory_update",
+      description:
+        "Update procedural memory. Replaces old_string with new_string in MEMORY.md. " +
+        "To append, use an empty old_string. " +
+        "Total content must not exceed 5000 characters. Write in English.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          old_string: {
+            type: "string",
+            description: "The text to find and replace. Empty string to append.",
+          },
+          new_string: {
+            type: "string",
+            description: "The replacement text.",
+          },
+          reason: {
+            type: "string",
+            description:
+              "Why this change is being made and what improvement is expected. " +
+              "This becomes the git commit message for future reference.",
+          },
+        },
+        required: ["old_string", "new_string", "reason"],
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  if (request.params.name !== "memory_update") {
+    return {
+      content: [{ type: "text", text: `Unknown tool: ${request.params.name}` }],
+      isError: true,
+    };
+  }
+
+  const { old_string, new_string, reason } = request.params.arguments as {
+    old_string: string;
+    new_string: string;
+    reason: string;
+  };
+
+  if (!reason || reason.trim().length === 0) {
+    return {
+      content: [{ type: "text", text: "reason is required." }],
+      isError: true,
+    };
+  }
+
+  const content = readMemory();
+
+  // apply edit
+  let updated: string;
+  if (old_string === "") {
+    updated = content + new_string;
+  } else {
+    const idx = content.indexOf(old_string);
+    if (idx === -1) {
+      return {
+        content: [{ type: "text", text: "old_string not found in memory." }],
+        isError: true,
+      };
+    }
+    if (content.indexOf(old_string, idx + 1) !== -1) {
+      return {
+        content: [{ type: "text", text: "old_string is ambiguous (multiple matches). Provide more context." }],
+        isError: true,
+      };
+    }
+    updated = content.slice(0, idx) + new_string + content.slice(idx + old_string.length);
+  }
+
+  // char limit check
+  if (updated.length > CHAR_LIMIT) {
+    return {
+      content: [{
+        type: "text",
+        text: `Rejected: result would be ${updated.length} chars, exceeding limit of ${CHAR_LIMIT}. Current: ${content.length} chars. Free: ${CHAR_LIMIT - content.length} chars.`,
+      }],
+      isError: true,
+    };
+  }
+
+  // write + git commit + push
+  writeFileSync(filePath, updated, "utf-8");
+
+  try {
+    git("add", MEMORY_FILE);
+    const diff = git("diff", "--cached", "--stat");
+    if (!diff) {
+      return { content: [{ type: "text", text: "No changes detected." }] };
+    }
+
+    const commitMsg = `memory: ${reason}\n\n(${updated.length}/${CHAR_LIMIT} chars)`;
+    git("commit", "-m", commitMsg);
+    git("push");
+  } catch (e) {
+    return {
+      content: [{ type: "text", text: `Git error: ${(e as Error).message}` }],
+      isError: true,
+    };
+  }
+
+  return {
+    content: [{
+      type: "text",
+      text: `Updated. ${updated.length}/${CHAR_LIMIT} chars used.`,
+    }],
+  };
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcp-memory/tsconfig.json
+++ b/mcp-memory/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- **Fix shell injection in mcp-memory**: Replace `execSync` with `execFileSync` to avoid shell interpretation of commit messages. Previously, special characters (backticks, $, newlines) in the `reason` parameter could cause command injection or failures.
- **Make Slack report channel configurable**: Extract hardcoded channel ID `C0AHU2XDBT2` to `AHA_REPORT_CHANNEL` environment variable with backward-compatible default.
- **Add git clone retry**: The memory repo clone in entrypoint.sh now retries up to 3 times with a 2-second delay, handling transient network failures in containers.

## Test plan
- [ ] Verify mcp-memory TypeScript compiles successfully
- [ ] Test memory_update with special characters in reason (backticks, $vars, newlines)
- [ ] Verify Slack channel override works with AHA_REPORT_CHANNEL env var
- [ ] Verify default channel still works without the env var
- [ ] Test git clone retry by simulating network failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)