### PR TITLE
feat: add branch protection rulesets for aha, aha-memory, docgen

### DIFF
--- a/scripts/github_admin/repo_rulesets_config.json
+++ b/scripts/github_admin/repo_rulesets_config.json
@@ -7,5 +7,16 @@
   },
   "tmn-cc-settings": {
     "skip": ["ruleset.json"]
+  },
+  "aha-memory": {
+    "skip": ["ruleset.json", "ruleset_develop.json"],
+    "add": ["ruleset_main_force_push_only.json"]
+  },
+  "aha": {
+    "skip": ["ruleset_develop.json"]
+  },
+  "docgen": {
+    "skip": ["ruleset.json", "ruleset_develop.json"],
+    "add": ["ruleset_main_force_push_only.json"]
   }
 }

--- a/scripts/github_admin/ruleset_main_force_push_only.json
+++ b/scripts/github_admin/ruleset_main_force_push_only.json
@@ -12,6 +12,9 @@
   },
   "rules": [
     {
+      "type": "deletion"
+    },
+    {
       "type": "non_fast_forward"
     }
   ],

--- a/scripts/github_admin/ruleset_main_force_push_only.json
+++ b/scripts/github_admin/ruleset_main_force_push_only.json
@@ -1,0 +1,30 @@
+{
+  "name": "Main Force Push Protection By Security",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "non_fast_forward"
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 10349524,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- aha: main protection (PR required, force push 금지), develop skip
- aha-memory: force push only protection
- docgen: force push only protection
- `ruleset_main_force_push_only.json`을 `github_admin/`으로 이동 (PR #41 리네이밍 반영)

## Test plan
- [x] `add_ruleset.py --dry-run`으로 적용 대상 확인
- [x] `add_ruleset.py`로 실제 적용 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)