### PR TITLE
Add Sentry SDK integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@
 import asyncio
 import os
 
+import sentry_sdk
 from dotenv import load_dotenv
 from slack_bolt.async_app import AsyncApp, AsyncAssistant
 from slack_bolt.adapter.socket_mode.aiohttp import AsyncSocketModeHandler
@@ -16,6 +17,8 @@ from app.justin import register_justin_handlers
 
 # 환경 변수 로드
 load_dotenv()
+
+sentry_sdk.init(dsn=os.environ.get("SENTRY_DSN", ""))
 
 # 앱 초기화
 app = AsyncApp(token=os.environ.get("SLACK_BOT_TOKEN"))

--- a/main.py
+++ b/main.py
@@ -18,8 +18,11 @@ import uvicorn
 from app.common import notion_page_to_markdown
 from github import Github, GithubException
 from dotenv import load_dotenv
+import sentry_sdk
 
 load_dotenv()
+
+sentry_sdk.init(dsn=os.environ.get("SENTRY_DSN", ""))
 
 # ============================================================================
 # 로깅 설정

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ boto3
 pandas
 matplotlib
 anthropic
+sentry-sdk[fastapi]


### PR DESCRIPTION
app.py (Slack bot)와 main.py (FastAPI) 모두에 Sentry SDK를 추가하여 런타임 에러를 모니터링합니다.

## 변경 사항
- app.py: `sentry_sdk.init()` 추가
- main.py: `sentry_sdk.init()` 추가
- requirements.txt: `sentry-sdk[fastapi]` 추가

## 참고
- SENTRY_DSN 환경 변수는 helm chart PR에서 별도 추가 (jce-service-helm)