### PR TITLE
feat: Justin 봇 멘션 메시지 전문을 피드백 에이전트에 전달

### DIFF
--- a/app/justin.py
+++ b/app/justin.py
@@ -260,8 +260,7 @@ async def _handle_notion_feedback(
 
     user_instructions = _extract_user_instructions(text)
     instructions_block = (
-        f"\n\n---\n\n"
-        f"## 요청자의 추가 지시사항\n\n{user_instructions}\n"
+        f"\n\n---\n\n" f"## 요청자의 추가 지시사항\n\n{user_instructions}\n"
         if user_instructions
         else ""
     )
@@ -298,7 +297,9 @@ async def _handle_notion_feedback(
     )
 
 
-async def _handle_pdf_feedback(app, say, pdf_files, user_real_name, text, thread_ts, channel):
+async def _handle_pdf_feedback(
+    app, say, pdf_files, user_real_name, text, thread_ts, channel
+):
     """PDF 첨부파일 기반 제안서 피드백을 처리합니다. (Claude 네이티브 PDF 지원)"""
     pdf_file = pdf_files[0]  # 첫 번째 PDF만 처리
     file_name = pdf_file.get("name", "제안서.pdf")

--- a/app/justin.py
+++ b/app/justin.py
@@ -44,7 +44,6 @@ def _load_prompt_file(filename: str) -> str:
     return content
 
 
-
 def extract_notion_page_id(text: str) -> str | None:
     """Slack 메시지에서 Notion 페이지 ID(32자 hex)를 추출합니다."""
     # Slack이 URL을 <url|label> 형식으로 감쌀 수 있으므로 < > 안도 탐색


### PR DESCRIPTION
## Summary
- Justin 봇을 멘션할 때 사용자가 작성한 추가 지시사항(예: "미완성임을 고려하고 XXX 영역만 리뷰해주세요")이 Claude에 전달되지 않던 문제를 수정합니다.
- `_extract_user_instructions()` 헬퍼를 추가하여 멘션 텍스트에서 봇 멘션과 URL을 제거하고, 남은 텍스트를 "요청자의 추가 지시사항"으로 프롬프트에 포함합니다.
- Notion 피드백과 PDF 피드백 모두에 적용됩니다.

## Test plan
- [ ] Justin 봇을 멘션하면서 Notion 링크 + 추가 지시사항을 함께 전달했을 때, 피드백이 지시사항을 반영하는지 확인
- [ ] PDF 첨부 + 추가 지시사항을 함께 전달했을 때, 피드백이 지시사항을 반영하는지 확인
- [ ] 추가 지시사항 없이 기존처럼 멘션만 했을 때 기존과 동일하게 동작하는지 확인

Notion task: https://www.notion.so/team-mono/Justin-3141cc820da681cf917fdf95c58f9822

🤖 Generated with [Claude Code](https://claude.com/claude-code)