### PR TITLE
Filter ClientConnectionResetError from Sentry

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 
 import sentry_sdk
+from aiohttp import ClientConnectionResetError
 from dotenv import load_dotenv
 from slack_bolt.async_app import AsyncApp, AsyncAssistant
 from slack_bolt.adapter.socket_mode.aiohttp import AsyncSocketModeHandler
@@ -18,7 +19,19 @@ from app.justin import register_justin_handlers
 # 환경 변수 로드
 load_dotenv()
 
-sentry_sdk.init(dsn=os.environ.get("SENTRY_DSN", ""))
+
+def _before_send(event, hint):
+    if "exc_info" in hint:
+        _, exc_value, _ = hint["exc_info"]
+        if isinstance(exc_value, ClientConnectionResetError):
+            return None
+    return event
+
+
+sentry_sdk.init(
+    dsn=os.environ.get("SENTRY_DSN", ""),
+    before_send=_before_send,
+)
 
 # 앱 초기화
 app = AsyncApp(token=os.environ.get("SLACK_BOT_TOKEN"))


### PR DESCRIPTION
## Summary
- `app.py`의 `sentry_sdk.init()`에 `before_send` 훅을 추가하여 `aiohttp.ClientConnectionResetError`를 Sentry에 보고하지 않도록 필터링
- aiohttp 내부 heartbeat 태스크에서 발생하는 WebSocket 연결 끊김 예외로, SDK의 자동 재연결이 이미 처리하지만 asyncio integration을 통해 Sentry에 노이즈로 보고되던 문제 해결

## Background
- Slack Socket Mode의 장기 WebSocket 연결은 서버 측 종료, heartbeat 타이밍 충돌, K8s 네트워크 이슈 등으로 주기적으로 끊김
- Slack SDK가 `auto_reconnect`로 자동 복구하지만, aiohttp의 별도 heartbeat asyncio Task에서 발생하는 `ClientConnectionResetError`는 SDK의 try/except 밖에서 발생
- `sentry-sdk[fastapi]`의 asyncio integration이 이 unhandled exception을 포착하여 보고
- 커뮤니티에서 잘 알려진 패턴 (slack-sdk#1110, aiohttp#5182 등)

## Test plan
- [ ] PR 머지 후 Sentry에서 `ClientConnectionResetError` 이벤트가 더 이상 보고되지 않는지 확인
- [ ] 기존 Sentry 기능(다른 에러 보고)이 정상 동작하는지 확인

Notion: AHA-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)