### PR TITLE
배포 예정 과업 메시지에 순번 추가

### DIFF
--- a/app/summarize_deployment.py
+++ b/app/summarize_deployment.py
@@ -181,7 +181,7 @@ def summarize_deployment(
     else:
         message = "오늘 배포 예정 과업!\n"
 
-    for task in tasks:
+    for task_number, task in enumerate(tasks, start=1):
         props = task["properties"]
 
         # 2) 담당자(people 속성)에서 이메일을 추출하여 Slack 멘션 처리
@@ -228,7 +228,7 @@ def summarize_deployment(
         )
 
         # 메시지 구성
-        message_line: str = f"{assignee_mention} {task_title_link} ({pr_links_str})\n"
+        message_line: str = f"{task_number}. {assignee_mention} {task_title_link} ({pr_links_str})\n"
         message += message_line
 
     # 레포지토리 안내 추가

--- a/app/summarize_deployment.py
+++ b/app/summarize_deployment.py
@@ -228,7 +228,9 @@ def summarize_deployment(
         )
 
         # 메시지 구성
-        message_line: str = f"{task_number}. {assignee_mention} {task_title_link} ({pr_links_str})\n"
+        message_line: str = (
+            f"{task_number}. {assignee_mention} {task_title_link} ({pr_links_str})\n"
+        )
         message += message_line
 
     # 레포지토리 안내 추가


### PR DESCRIPTION
## Summary
- 배포 예정 과업 메시지의 각 항목에 순번(1., 2., 3., ...)을 추가하여 가독성 향상
- `enumerate(tasks, start=1)`을 사용하여 구현

## Before
```
오늘 배포 예정 과업!
@김세윤 SAML ACS 엔드포인트 분기 (jce-user-rails#323)
@곽병환 PR 2: EF 시작코드 편집 (No PR Link)
```

## After
```
오늘 배포 예정 과업!
1. @김세윤 SAML ACS 엔드포인트 분기 (jce-user-rails#323)
2. @곽병환 PR 2: EF 시작코드 편집 (No PR Link)
```

## Test plan
- [ ] `/summarize-deployment` 명령어로 메시지가 순번 포함해서 정상 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)