### PR TITLE
feat: 탐색팀 스크럼 자동화 추가

### DIFF
--- a/scripts/post_scrum_message.py
+++ b/scripts/post_scrum_message.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import argparse
 import os
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
@@ -24,10 +25,41 @@ from service.teams import ALL_TEAM_USERGROUP_IDS
 load_dotenv()
 
 # 상수 정의
-MAIN_DATA_SOURCE_ID = "3e050c5a-11f3-4a3e-b6d0-498fe06c9d7b"
 SCRUM_CHANNEL_ID = "C09277NGUET"
 
 USER_CHANGWHAN = "U02HT4EU4VD"
+
+
+@dataclass(frozen=True)
+class NotionDBConfig:
+    """Notion DB별 프로퍼티 매핑 설정"""
+
+    data_source_id: str
+    title_property: str
+    status_property: str
+    in_progress_statuses: list[str] = field(default_factory=list)
+    assignee_property: str = "담당자"
+    date_property: str = "타임라인"
+    pr_property: str | None = "GitHub 풀 리퀘스트"
+
+
+MAIN_DB_CONFIG = NotionDBConfig(
+    data_source_id="3e050c5a-11f3-4a3e-b6d0-498fe06c9d7b",
+    title_property="제목",
+    status_property="상태",
+    in_progress_statuses=["진행", "리뷰"],
+    date_property="타임라인",
+    pr_property="GitHub 풀 리퀘스트",
+)
+
+EXPLORE_DB_CONFIG = NotionDBConfig(
+    data_source_id="3141cc82-0da6-8103-913c-000ba234b439",
+    title_property="작업",
+    status_property="진행 상태",
+    in_progress_statuses=["진행 중", "테스트 중"],
+    date_property="마감일",
+    pr_property=None,
+)
 
 
 def main():
@@ -69,7 +101,18 @@ def main():
     # 5. IE팀 스크럼
     send_team_scrum(notion, slack_client, email_to_user_id, "ie", "IE", args.dry_run)
 
-    # 6. 이창환 스크럼
+    # 6. 탐색팀 스크럼
+    send_team_scrum(
+        notion,
+        slack_client,
+        email_to_user_id,
+        "탐색",
+        "탐색",
+        args.dry_run,
+        db_config=EXPLORE_DB_CONFIG,
+    )
+
+    # 7. 이창환 스크럼
     send_personal_scrum(slack_client, args.dry_run)
 
     if args.dry_run:
@@ -129,6 +172,7 @@ def send_team_scrum(
     team_handle: str,
     team_name: str,
     dry_run: bool = False,
+    db_config: NotionDBConfig = MAIN_DB_CONFIG,
 ):
     """
     팀별 스크럼 메시지 발송 (Notion에서 진행 중인 태스크 조회)
@@ -140,6 +184,7 @@ def send_team_scrum(
         team_handle: 팀 핸들 (예: "fe", "be", "ie")
         team_name: 팀 이름 (예: "FE", "BE", "IE")
         dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
+        db_config: Notion DB 설정 (기본값: MAIN_DB_CONFIG)
     """
     # 메인 메시지
     text = f"{team_name}팀 스크럼"
@@ -155,7 +200,7 @@ def send_team_scrum(
     ]
 
     # Notion에서 진행 중인 태스크 조회
-    in_progress_tasks = get_in_progress_tasks(notion, team_emails)
+    in_progress_tasks = get_in_progress_tasks(notion, team_emails, db_config)
 
     # 이메일별로 태스크 그룹화
     email_to_tasks = {}
@@ -176,8 +221,8 @@ def send_team_scrum(
 
         # 인원별 메시지 생성
         person_message = f"{assignee_name}\n"
-        # 기획팀 여부 확인
-        is_planning_team = team_handle == "기획"
+        # PR 경고 비활성화 여부 (기획팀이거나 PR 프로퍼티가 없는 DB)
+        is_planning_team = team_handle == "기획" or db_config.pr_property is None
         for task in tasks:
             task_line = format_task_line(task, is_planning_team)
             person_message += f"{task_line}\n"
@@ -254,7 +299,9 @@ def get_team_members(slack_client: WebClient, team_handle: str) -> list[str]:
 
 
 def get_in_progress_tasks(
-    notion: NotionClient, team_emails: list[str]
+    notion: NotionClient,
+    team_emails: list[str],
+    db_config: NotionDBConfig = MAIN_DB_CONFIG,
 ) -> list[dict[str, Any]]:
     """
     Notion에서 팀 멤버들의 진행 중인 태스크 조회
@@ -262,27 +309,27 @@ def get_in_progress_tasks(
     Args:
         notion: Notion Client
         team_emails: 팀 멤버 이메일 목록
+        db_config: Notion DB 설정
 
     Returns:
         list[dict]: 태스크 정보 목록
     """
-    # 진행 또는 리뷰 상태의 태스크 조회
+    # 진행 중 상태의 태스크 조회 (DB별 상태값 사용)
+    status_filters = [
+        {"property": db_config.status_property, "status": {"equals": status}}
+        for status in db_config.in_progress_statuses
+    ]
     results = notion.data_sources.query(
         **{
-            "data_source_id": MAIN_DATA_SOURCE_ID,
-            "filter": {
-                "or": [
-                    {"property": "상태", "status": {"equals": "진행"}},
-                    {"property": "상태", "status": {"equals": "리뷰"}},
-                ]
-            },
+            "data_source_id": db_config.data_source_id,
+            "filter": {"or": status_filters},
         }
     )
 
     tasks = []
     for result in results.get("results", []):
         # 담당자 확인
-        people = result["properties"]["담당자"].get("people", [])
+        people = result["properties"][db_config.assignee_property].get("people", [])
         if not people:
             continue
 
@@ -296,22 +343,24 @@ def get_in_progress_tasks(
 
         # 태스크 정보 추출
         try:
-            title_prop = result["properties"]["제목"]["title"]
+            title_prop = result["properties"][db_config.title_property]["title"]
             title = title_prop[0]["text"]["content"] if title_prop else "제목 없음"
         except (KeyError, IndexError):
             title = "제목 없음"
 
-        # 타임라인 (마감일)
-        timeline = result["properties"]["타임라인"].get("date")
+        # 마감일
+        date_value = result["properties"][db_config.date_property].get("date")
         deadline = (
-            timeline["end"]
-            if timeline and timeline.get("end")
-            else (timeline["start"] if timeline else None)
+            date_value["end"]
+            if date_value and date_value.get("end")
+            else (date_value["start"] if date_value else None)
         )
 
         # GitHub PR 연결 여부
-        github_prs = result["properties"]["GitHub 풀 리퀘스트"]["relation"]
-        has_pr = len(github_prs) > 0
+        has_pr = False
+        if db_config.pr_property:
+            github_prs = result["properties"][db_config.pr_property]["relation"]
+            has_pr = len(github_prs) > 0
 
         # 담당자 이름
         assignee_name = people[0].get("name", "")

--- a/scripts/schedule_scrum_mention.py
+++ b/scripts/schedule_scrum_mention.py
@@ -26,6 +26,7 @@ TEAM_MENTIONS = {
     "FE": get_team_mention("fe"),
     "BE": get_team_mention("be"),
     "IE": get_team_mention("ie"),
+    "탐색": get_team_mention("탐색"),
     "이창환": "<@U02HT4EU4VD>",
 }
 
@@ -71,7 +72,7 @@ def main():
             print(f"텍스트: {text[:100]}{'...' if len(text) > 100 else ''}")
 
             # 팀별 스크럼 메시지 매칭 (타임스탬프 제거됨)
-            for team_name in ["기획", "FE", "BE", "IE", "이창환"]:
+            for team_name in ["기획", "FE", "BE", "IE", "탐색", "이창환"]:
                 if f"{team_name}팀 스크럼" in text or f"{team_name} 스크럼" in text:
                     team_threads[team_name] = message["ts"]
                     print(f"✓ {team_name} 팀 스레드 발견 (ts: {ts})")

--- a/service/teams.py
+++ b/service/teams.py
@@ -13,9 +13,10 @@ TEAM_USERGROUP_IDS: dict[Literal["fe", "be", "ie"], str] = {
     "ie": "S08628PEEUQ",
 }
 
-# 전체 팀 Slack 사용자 그룹 ID (기획팀 포함)
+# 전체 팀 Slack 사용자 그룹 ID (기획팀, 탐색팀 포함)
 ALL_TEAM_USERGROUP_IDS: dict[str, str] = {
     "기획": "S092KHHE0AF",
+    "탐색": "S0AJD6M5LH4",
     **TEAM_USERGROUP_IDS,
 }
 


### PR DESCRIPTION
## Summary
- 탐색팀의 별도 Notion DB(탐색팀 작업, `3141cc82-0da6-81b4-b59a-d7787b81eebe`)를 사용하여 스크럼 자동화 추가
- 기존 DB와 프로퍼티 명이 다른 점을 `NotionDBConfig` 데이터클래스로 추상화하여 팀별 DB 설정을 유연하게 지원
- 탐색팀 Slack 유저그룹(`S0AJD6M5LH4`) 등록 및 스크럼 멘션 매칭 추가

### 변경 내용
| 파일 | 변경 |
|------|------|
| `service/teams.py` | 탐색 유저그룹 ID 추가 |
| `scripts/post_scrum_message.py` | `NotionDBConfig` 도입, 탐색팀 스크럼 발송 추가 |
| `scripts/schedule_scrum_mention.py` | 탐색팀 멘션 매칭 추가 |

### 탐색팀 DB 프로퍼티 매핑
| 기존 DB | 탐색팀 DB |
|---------|----------|
| `제목` (title) | `작업` (title) |
| `상태` ("진행", "리뷰") | `진행 상태` ("진행 중", "테스트 중") |
| `타임라인` (date) | `마감일` (date) |
| `GitHub 풀 리퀘스트` (relation) | 없음 |

## Test plan
- [ ] `--dry-run` 모드로 탐색팀 스크럼 메시지 생성 확인
- [ ] 탐색팀 Notion DB에 진행 중 태스크가 있을 때 정상 조회 확인
- [ ] 멘션 스케줄러가 "탐색팀 스크럼" 메시지를 정상 매칭하는지 확인

Notion task: https://www.notion.so/3191cc820da6815faf05d1b736ea0d9e

🤖 Generated with [Claude Code](https://claude.com/claude-code)