### PR TITLE
feat: 탐색팀 스크럼 자동 메시지 추가

### DIFF
--- a/scripts/post_scrum_message.py
+++ b/scripts/post_scrum_message.py
@@ -72,6 +72,9 @@ def main():
     # 6. 이창환 스크럼
     send_personal_scrum(slack_client, args.dry_run)
 
+    # 7. 탐색팀 스크럼
+    send_simple_scrum(slack_client, "탐색팀", args.dry_run)
+
     if args.dry_run:
         print("\n=== DRY RUN COMPLETED ===")
 
@@ -220,6 +223,29 @@ def send_personal_scrum(slack_client: WebClient, dry_run: bool = False):
 
     if dry_run:
         print(f"\n[이창환 스크럼]")
+        print(text)
+    else:
+        slack_client.chat_postMessage(
+            channel=SCRUM_CHANNEL_ID,
+            text=text,
+        )
+
+
+def send_simple_scrum(
+    slack_client: WebClient, name: str, dry_run: bool = False
+):
+    """
+    Notion 태스크 조회 없이 단순 스크럼 메시지만 발송
+
+    Args:
+        slack_client: Slack WebClient
+        name: 스크럼 이름 (예: "탐색팀")
+        dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
+    """
+    text = f"{name} 스크럼"
+
+    if dry_run:
+        print(f"\n[{name} 스크럼]")
         print(text)
     else:
         slack_client.chat_postMessage(

--- a/scripts/post_scrum_message.py
+++ b/scripts/post_scrum_message.py
@@ -231,9 +231,7 @@ def send_personal_scrum(slack_client: WebClient, dry_run: bool = False):
         )
 
 
-def send_simple_scrum(
-    slack_client: WebClient, name: str, dry_run: bool = False
-):
+def send_simple_scrum(slack_client: WebClient, name: str, dry_run: bool = False):
     """
     Notion 태스크 조회 없이 단순 스크럼 메시지만 발송
 

--- a/scripts/schedule_scrum_mention.py
+++ b/scripts/schedule_scrum_mention.py
@@ -27,6 +27,7 @@ TEAM_MENTIONS = {
     "BE": get_team_mention("be"),
     "IE": get_team_mention("ie"),
     "이창환": "<@U02HT4EU4VD>",
+    "탐색팀": get_team_mention("탐색"),
 }
 
 
@@ -71,7 +72,7 @@ def main():
             print(f"텍스트: {text[:100]}{'...' if len(text) > 100 else ''}")
 
             # 팀별 스크럼 메시지 매칭 (타임스탬프 제거됨)
-            for team_name in ["기획", "FE", "BE", "IE", "이창환"]:
+            for team_name in ["기획", "FE", "BE", "IE", "이창환", "탐색팀"]:
                 if f"{team_name}팀 스크럼" in text or f"{team_name} 스크럼" in text:
                     team_threads[team_name] = message["ts"]
                     print(f"✓ {team_name} 팀 스레드 발견 (ts: {ts})")

--- a/service/teams.py
+++ b/service/teams.py
@@ -13,9 +13,10 @@ TEAM_USERGROUP_IDS: dict[Literal["fe", "be", "ie"], str] = {
     "ie": "S08628PEEUQ",
 }
 
-# 전체 팀 Slack 사용자 그룹 ID (기획팀 포함)
+# 전체 팀 Slack 사용자 그룹 ID (기획팀, 탐색팀 포함)
 ALL_TEAM_USERGROUP_IDS: dict[str, str] = {
     "기획": "S092KHHE0AF",
+    "탐색": "S0AJD6M5LH4",
     **TEAM_USERGROUP_IDS,
 }
 


### PR DESCRIPTION
## Summary
- 이창환 스크럼 아래에 탐색팀 스크럼 자동 메시지 발송 기능 추가
- 탐색팀 usergroup(`S0AJD6M5LH4`)을 `teams.py`에 등록
- 스크럼 메시지 발송 시 "탐색팀 스크럼" 메시지 추가 (`post_scrum_message.py`)
- 스크럼 멘션 시 탐색팀 태그 추가 (`schedule_scrum_mention.py`)

## Test plan
- [ ] `post_scrum_message.py --dry-run` 실행하여 탐색팀 스크럼 메시지 출력 확인
- [ ] `schedule_scrum_mention.py` 에서 탐색팀 매칭 로직 확인

Notion: https://www.notion.so/3191cc820da681549ef5fefde72667a5

🤖 Generated with [Claude Code](https://claude.com/claude-code)