### PR TITLE
feat: 스케줄 워크플로우 대한민국 공휴일 스킵

### DIFF
--- a/.github/workflows/manage_tasks_daily.yaml
+++ b/.github/workflows/manage_tasks_daily.yaml
@@ -19,7 +19,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Check Korean public holiday
+        id: holiday_check
+        if: github.event_name == 'schedule'
+        env:
+          DATA_GO_KR_SPECIAL_DAY_KEY: ${{ secrets.DATA_GO_KR_SPECIAL_DAY_KEY }}
+        run: |
+          python -c "
+          import sys; sys.path.insert(0, '.')
+          from datetime import datetime, timezone, timedelta
+          from service.business_days import is_business_day
+          today = datetime.now(timezone(timedelta(hours=9))).date()
+          if not is_business_day(today):
+              print(f'{today} is not a business day. Skipping.')
+              with open('$GITHUB_OUTPUT', 'a') as f: f.write('skip=true\n')
+          else:
+              print(f'{today} is a business day. Proceeding.')
+          "
       - name: Run manage_tasks_daily.py
+        if: steps.holiday_check.outputs.skip != 'true'
         env:
           NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
           NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}

--- a/.github/workflows/notify_upcoming_workevent.yaml
+++ b/.github/workflows/notify_upcoming_workevent.yaml
@@ -18,7 +18,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Check Korean public holiday
+        id: holiday_check
+        if: github.event_name == 'schedule'
+        env:
+          DATA_GO_KR_SPECIAL_DAY_KEY: ${{ secrets.DATA_GO_KR_SPECIAL_DAY_KEY }}
+        run: |
+          python -c "
+          import sys; sys.path.insert(0, '.')
+          from datetime import datetime, timezone, timedelta
+          from service.business_days import is_business_day
+          today = datetime.now(timezone(timedelta(hours=9))).date()
+          if not is_business_day(today):
+              print(f'{today} is not a business day. Skipping.')
+              with open('$GITHUB_OUTPUT', 'a') as f: f.write('skip=true\n')
+          else:
+              print(f'{today} is a business day. Proceeding.')
+          "
       - name: Run notify_upcoming_workevent.py
+        if: steps.holiday_check.outputs.skip != 'true'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           WANTEDSPACE_API_KEY: ${{ secrets.WANTEDSPACE_API_KEY }}

--- a/.github/workflows/notify_worktime_left.yaml
+++ b/.github/workflows/notify_worktime_left.yaml
@@ -19,7 +19,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Check Korean public holiday
+        id: holiday_check
+        if: github.event_name == 'schedule'
+        env:
+          DATA_GO_KR_SPECIAL_DAY_KEY: ${{ secrets.DATA_GO_KR_SPECIAL_DAY_KEY }}
+        run: |
+          python -c "
+          import sys; sys.path.insert(0, '.')
+          from datetime import datetime, timezone, timedelta
+          from service.business_days import is_business_day
+          today = datetime.now(timezone(timedelta(hours=9))).date()
+          if not is_business_day(today):
+              print(f'{today} is not a business day. Skipping.')
+              with open('$GITHUB_OUTPUT', 'a') as f: f.write('skip=true\n')
+          else:
+              print(f'{today} is a business day. Proceeding.')
+          "
       - name: Run notify_worktime_left.py
+        if: steps.holiday_check.outputs.skip != 'true'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           WANTEDSPACE_API_KEY: ${{ secrets.WANTEDSPACE_API_KEY }}

--- a/.github/workflows/post_scrum_message.yaml
+++ b/.github/workflows/post_scrum_message.yaml
@@ -18,7 +18,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Check Korean public holiday
+        id: holiday_check
+        if: github.event_name == 'schedule'
+        env:
+          DATA_GO_KR_SPECIAL_DAY_KEY: ${{ secrets.DATA_GO_KR_SPECIAL_DAY_KEY }}
+        run: |
+          python -c "
+          import sys; sys.path.insert(0, '.')
+          from datetime import datetime, timezone, timedelta
+          from service.business_days import is_business_day
+          today = datetime.now(timezone(timedelta(hours=9))).date()
+          if not is_business_day(today):
+              print(f'{today} is not a business day. Skipping.')
+              with open('$GITHUB_OUTPUT', 'a') as f: f.write('skip=true\n')
+          else:
+              print(f'{today} is a business day. Proceeding.')
+          "
       - name: Run post_scrum_message.py
+        if: steps.holiday_check.outputs.skip != 'true'
         env:
           NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/schedule_scrum_mention.yaml
+++ b/.github/workflows/schedule_scrum_mention.yaml
@@ -18,7 +18,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Check Korean public holiday
+        id: holiday_check
+        if: github.event_name == 'schedule'
+        env:
+          DATA_GO_KR_SPECIAL_DAY_KEY: ${{ secrets.DATA_GO_KR_SPECIAL_DAY_KEY }}
+        run: |
+          python -c "
+          import sys; sys.path.insert(0, '.')
+          from datetime import datetime, timezone, timedelta
+          from service.business_days import is_business_day
+          today = datetime.now(timezone(timedelta(hours=9))).date()
+          if not is_business_day(today):
+              print(f'{today} is not a business day. Skipping.')
+              with open('$GITHUB_OUTPUT', 'a') as f: f.write('skip=true\n')
+          else:
+              print(f'{today} is a business day. Proceeding.')
+          "
       - name: Run schedule_scrum_mention.py
+        if: steps.holiday_check.outputs.skip != 'true'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         run: |

--- a/.github/workflows/validate_customer_reports.yaml
+++ b/.github/workflows/validate_customer_reports.yaml
@@ -19,7 +19,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Check Korean public holiday
+        id: holiday_check
+        if: github.event_name == 'schedule'
+        env:
+          DATA_GO_KR_SPECIAL_DAY_KEY: ${{ secrets.DATA_GO_KR_SPECIAL_DAY_KEY }}
+        run: |
+          python -c "
+          import sys; sys.path.insert(0, '.')
+          from datetime import datetime, timezone, timedelta
+          from service.business_days import is_business_day
+          today = datetime.now(timezone(timedelta(hours=9))).date()
+          if not is_business_day(today):
+              print(f'{today} is not a business day. Skipping.')
+              with open('$GITHUB_OUTPUT', 'a') as f: f.write('skip=true\n')
+          else:
+              print(f'{today} is a business day. Proceeding.')
+          "
       - name: Run validate_customer_reports.py
+        if: steps.holiday_check.outputs.skip != 'true'
         env:
           NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
           SLACK_BOT_TOKEN_JUSTIN: ${{ secrets.SLACK_BOT_TOKEN_JUSTIN }}


### PR DESCRIPTION
## Summary
- 스케줄 트리거로 실행되는 6개 워크플로우에 대한민국 공휴일 체크 스텝 추가
- 공휴일이면 메인 스크립트 실행을 건너뜀 (주말도 마찬가지)
- `workflow_dispatch` (수동 실행)는 공휴일 체크 없이 항상 실행됨
- 기존 `service/business_days.py`의 `is_business_day()` 함수와 공공데이터포털 API 활용

### 대상 워크플로우
| 워크플로우 | 설명 |
|---|---|
| `post_scrum_message` | 스크럼 메시지 발송 |
| `schedule_scrum_mention` | 스크럼 멘션 발송 |
| `manage_tasks_daily` | 일일 태스크 관리 |
| `notify_worktime_left` | 잔여 근무시간 알림 |
| `notify_upcoming_workevent` | 근무 이벤트 알림 |
| `validate_customer_reports` | 고객 보고서 검증 |

### 제외된 워크플로우
- `collect_review_stats` - 주간 데이터 수집 (알림이 아닌 통계)
- `collect_coding_rule_feedbacks` - 주간 데이터 수집

## Test plan
- [ ] 수동 실행(`workflow_dispatch`)으로 각 워크플로우가 정상 동작하는지 확인
- [ ] 공휴일 체크 스텝이 올바르게 `skip=true` 출력하는지 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)