### PR TITLE
슬랙 이벤트 중복 처리 방지

### DIFF
--- a/app/general.py
+++ b/app/general.py
@@ -6,6 +6,7 @@ import asyncio
 from datetime import datetime, timedelta
 import logging
 
+from cachetools import TTLCache
 from slack_bolt.async_app import AsyncBoltContext, AsyncSetStatus
 from slack_sdk.web.async_client import AsyncWebClient
 
@@ -34,6 +35,10 @@ SLACK_DEV_ENV_INFRA_BUG_CHANNEL_ID = "C096HGFDFM1"
 
 USER_ID_TO_LAST_HUDDLE_JOINED_AT = {}
 
+# 이벤트 중복 처리 방지를 위한 캐시 (TTL 60초, 최대 1000건)
+# Slack Socket Mode에서 동시 요청 시 같은 이벤트가 중복 전달될 수 있음
+_processed_events: TTLCache = TTLCache(maxsize=1000, ttl=60)
+
 
 def register_general_handlers(app, assistant):
     """
@@ -49,6 +54,12 @@ def register_general_handlers(app, assistant):
 
         if event is None:
             return
+
+        # 이벤트 중복 처리 방지: event_ts를 키로 사용하여 이미 처리된 이벤트는 무시
+        event_ts = event.get("ts")
+        if event_ts in _processed_events:
+            return
+        _processed_events[event_ts] = True
 
         thread_ts = event.get("thread_ts") or body["event"]["ts"]
         channel = event["channel"]
@@ -97,6 +108,13 @@ def register_general_handlers(app, assistant):
         print("Received message event:", body)
 
         event = body.get("event", {})
+
+        # 이벤트 중복 처리 방지
+        event_ts = event.get("ts")
+        if event_ts in _processed_events:
+            return
+        _processed_events[event_ts] = True
+
         channel = event.get("channel")
         print(f"Channel: {channel}")
 
@@ -150,6 +168,13 @@ def register_general_handlers(app, assistant):
         """
         Respond to a user message in the assistant thread.
         """
+        # 이벤트 중복 처리 방지
+        event_ts = payload.get("ts") or payload.get("event_ts")
+        if event_ts and event_ts in _processed_events:
+            return
+        if event_ts:
+            _processed_events[event_ts] = True
+
         # Slack 스레드 링크 만들기
         slack_workspace = "monolith-keb2010"
         thread_ts_for_link = context.thread_ts.replace(".", "")

--- a/app/general.py
+++ b/app/general.py
@@ -62,7 +62,9 @@ def register_general_handlers(app, assistant):
         event_type = body.get("event", {}).get("type")
         logger.info(
             "app_mention received: event_ts=%s, channel=%s, event_type=%s",
-            event_ts, event.get("channel"), event_type,
+            event_ts,
+            event.get("channel"),
+            event_type,
         )
         if event_ts in _processed_events:
             logger.warning(
@@ -124,7 +126,10 @@ def register_general_handlers(app, assistant):
         event_subtype = event.get("subtype")
         logger.info(
             "message received: event_ts=%s, channel=%s, type=%s, subtype=%s",
-            event_ts, event.get("channel"), event_type, event_subtype,
+            event_ts,
+            event.get("channel"),
+            event_type,
+            event_subtype,
         )
         if event_ts in _processed_events:
             logger.warning(
@@ -191,7 +196,8 @@ def register_general_handlers(app, assistant):
         event_ts = payload.get("ts") or payload.get("event_ts")
         logger.info(
             "assistant.user_message received: event_ts=%s, channel=%s",
-            event_ts, context.channel_id,
+            event_ts,
+            context.channel_id,
         )
         if event_ts and event_ts in _processed_events:
             logger.warning(

--- a/app/general.py
+++ b/app/general.py
@@ -35,6 +35,8 @@ SLACK_DEV_ENV_INFRA_BUG_CHANNEL_ID = "C096HGFDFM1"
 
 USER_ID_TO_LAST_HUDDLE_JOINED_AT = {}
 
+logger = logging.getLogger(__name__)
+
 # 이벤트 중복 처리 방지를 위한 캐시 (TTL 60초, 최대 1000건)
 # Slack Socket Mode에서 동시 요청 시 같은 이벤트가 중복 전달될 수 있음
 _processed_events: TTLCache = TTLCache(maxsize=1000, ttl=60)
@@ -57,7 +59,16 @@ def register_general_handlers(app, assistant):
 
         # 이벤트 중복 처리 방지: event_ts를 키로 사용하여 이미 처리된 이벤트는 무시
         event_ts = event.get("ts")
+        event_type = body.get("event", {}).get("type")
+        logger.info(
+            "app_mention received: event_ts=%s, channel=%s, event_type=%s",
+            event_ts, event.get("channel"), event_type,
+        )
         if event_ts in _processed_events:
+            logger.warning(
+                "app_mention DUPLICATE blocked: event_ts=%s (already processed)",
+                event_ts,
+            )
             return
         _processed_events[event_ts] = True
 
@@ -105,13 +116,21 @@ def register_general_handlers(app, assistant):
         버그 신고 채널에 올라오는 메시지를 LLM으로 분석하여
         Notion에 버그 작업을 생성하고, 시급한 경우 담당 그룹을 태그합니다.
         """
-        print("Received message event:", body)
-
         event = body.get("event", {})
 
         # 이벤트 중복 처리 방지
         event_ts = event.get("ts")
+        event_type = event.get("type")
+        event_subtype = event.get("subtype")
+        logger.info(
+            "message received: event_ts=%s, channel=%s, type=%s, subtype=%s",
+            event_ts, event.get("channel"), event_type, event_subtype,
+        )
         if event_ts in _processed_events:
+            logger.warning(
+                "message DUPLICATE blocked: event_ts=%s (already processed)",
+                event_ts,
+            )
             return
         _processed_events[event_ts] = True
 
@@ -170,7 +189,15 @@ def register_general_handlers(app, assistant):
         """
         # 이벤트 중복 처리 방지
         event_ts = payload.get("ts") or payload.get("event_ts")
+        logger.info(
+            "assistant.user_message received: event_ts=%s, channel=%s",
+            event_ts, context.channel_id,
+        )
         if event_ts and event_ts in _processed_events:
+            logger.warning(
+                "assistant.user_message DUPLICATE blocked: event_ts=%s (already processed)",
+                event_ts,
+            )
             return
         if event_ts:
             _processed_events[event_ts] = True


### PR DESCRIPTION
## Summary
- Slack Socket Mode에서 동시 요청 시 같은 이벤트가 중복 전달되어 과업이 두 번 생성되는 현상 수정
- `app_mention`, `message`, `assistant.user_message` 핸들러에 TTLCache 기반 이벤트 중복 처리 방지 로직 추가
- 이벤트의 `ts` (타임스탬프)를 키로 사용하여 60초 내 동일 이벤트 재처리를 방지

## Root Cause
Slack Socket Mode에서 WebSocket 재연결 또는 부하 상황에서 같은 이벤트가 중복 전달될 수 있음. 기존에는 이에 대한 방어 로직이 없어 동시에 들어온 과업 생성 요청이 각각 두 번씩 처리됨.

## Test plan
- [ ] 슬랙에서 과업 생성을 동시에 두 건 이상 신청하여 중복 생성이 발생하지 않는지 확인
- [ ] 기존 단건 과업 생성이 정상 동작하는지 확인

Notion: https://www.notion.so/31e1cc820da681f4ba7ff79a6404a3e8

🤖 Generated with [Claude Code](https://claude.com/claude-code)