### PR TITLE
Sentry ClientConnectionResetError 로그 메시지 필터링 보완

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,18 @@ def _before_send(event, hint):
         _, exc_value, _ = hint["exc_info"]
         if isinstance(exc_value, ClientConnectionResetError):
             return None
+
+    message = event.get("message", "") or ""
+    logentry = event.get("logentry", {}) or {}
+    logentry_message = (
+        logentry.get("formatted", "") or logentry.get("message", "") or ""
+    )
+    if (
+        "ClientConnectionResetError" in message
+        or "ClientConnectionResetError" in logentry_message
+    ):
+        return None
+
     return event
 
 


### PR DESCRIPTION
## Summary
- `_before_send` 함수에서 `exc_info` 기반 필터링 외에 event의 `message` 및 `logentry` 필드에서도 `ClientConnectionResetError` 문자열을 확인하여 필터링하도록 보완
- Slack Bolt가 `ClientConnectionResetError`를 exception이 아닌 error-level 로그 메시지로 기록하는 경우에도 Sentry에서 필터링됨

## Test plan
- [ ] Sentry에서 `ClientConnectionResetError` 관련 로그 메시지 이벤트가 더 이상 보고되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)