### PR TITLE
봇 자기 자신 멘션 시 app_mention 이벤트 무시

### DIFF
--- a/app/contents.py
+++ b/app/contents.py
@@ -36,6 +36,10 @@ def register_contents_handlers(app_contents):
         if event is None:
             return
 
+        # 봇이 보낸 메시지는 무시 (자기 자신을 태그하는 무한 루프 방지)
+        if event.get("bot_id"):
+            return
+
         thread_ts = event.get("thread_ts") or body["event"]["ts"]
         channel = event["channel"]
         user = event.get("user")

--- a/app/data_bot.py
+++ b/app/data_bot.py
@@ -33,6 +33,10 @@ def register_data_handlers(app_data):
         if event is None:
             return
 
+        # 봇이 보낸 메시지는 무시 (자기 자신을 태그하는 무한 루프 방지)
+        if event.get("bot_id"):
+            return
+
         thread_ts = event.get("thread_ts") or body["event"]["ts"]
         channel = event["channel"]
         user = event.get("user")

--- a/app/general.py
+++ b/app/general.py
@@ -50,6 +50,10 @@ def register_general_handlers(app, assistant):
         if event is None:
             return
 
+        # 봇이 보낸 메시지는 무시 (자기 자신을 태그하는 무한 루프 방지)
+        if event.get("bot_id"):
+            return
+
         thread_ts = event.get("thread_ts") or body["event"]["ts"]
         channel = event["channel"]
         user = event.get("user")

--- a/app/justin.py
+++ b/app/justin.py
@@ -170,6 +170,10 @@ def register_justin_handlers(app):
         if event is None:
             return
 
+        # 봇이 보낸 메시지는 무시 (자기 자신을 태그하는 무한 루프 방지)
+        if event.get("bot_id"):
+            return
+
         thread_ts = event.get("thread_ts") or event["ts"]
         channel = event["channel"]
         user = event.get("user")


### PR DESCRIPTION
## Summary
- 봇이 자기 자신의 멘션을 포함한 메시지를 보냈을 때, Slack이 `app_mention` 이벤트를 다시 발생시켜 무한 루프가 발생하는 문제 수정
- 모든 `app_mention` 핸들러(general, contents, data_bot, justin)에 `event.get("bot_id")` 체크를 추가하여 봇이 보낸 메시지는 무시하도록 처리
- 실제 발생 사례: WF 봇이 노션 태스크 생성 결과 메시지에 자기 자신을 태그하여 동일 태스크가 4개 중복 생성됨

## Test plan
- [ ] WF 봇이 자기 자신을 멘션하는 메시지를 보냈을 때 무시되는지 확인
- [ ] 일반 사용자가 봇을 멘션했을 때 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)