### PR TITLE
read_redash_dashboard에서 textbox 위젯 text 필드 읽기 지원

### DIFF
--- a/app/tools/redash_tools.py
+++ b/app/tools/redash_tools.py
@@ -63,9 +63,16 @@ def read_redash_dashboard(
             result.append("이 대시보드에는 위젯이 없습니다.")
             return "\n".join(result)
 
-        # 쿼리 ID와 이름만 수집
+        # 텍스트박스와 쿼리 수집
+        text_list = []
         query_list = []
         for widget in widgets:
+            # textbox 위젯 처리
+            text_content = widget.get("text")
+            if text_content:
+                text_list.append(text_content)
+                continue
+
             visualization = widget.get("visualization")
             if not visualization:
                 continue
@@ -80,11 +87,18 @@ def read_redash_dashboard(
             if query_id:
                 query_list.append(f"- Query ID {query_id}: {query_name}")
 
+        if text_list:
+            result.append("## 텍스트\n")
+            for text in text_list:
+                result.append(text)
+                result.append("")
+
         if query_list:
             result.append("## 쿼리 목록\n")
             result.extend(query_list)
-        else:
-            result.append("이 대시보드에는 쿼리가 없습니다.")
+
+        if not text_list and not query_list:
+            result.append("이 대시보드에는 위젯이 없습니다.")
 
         return "\n".join(result)
     except Exception as e:

--- a/tests/test_data_bot.py
+++ b/tests/test_data_bot.py
@@ -209,6 +209,32 @@ class TestRedashTools:
         assert "Query ID 123" in result
         assert "Test Query" in result
 
+    @patch("api.redash.get_dashboard")
+    def test_read_redash_dashboard_textbox(self, mock_get_dashboard):
+        """Redash 대시보드 읽기 tool 테스트 - textbox 위젯 포함"""
+        mock_get_dashboard.return_value = {
+            "name": "Dashboard with Textbox",
+            "widgets": [
+                {"text": "# 안내사항\n이 대시보드는 매출 현황을 보여줍니다."},
+                {
+                    "visualization": {
+                        "query": {
+                            "id": 456,
+                            "name": "매출 쿼리",
+                        }
+                    }
+                },
+            ],
+        }
+
+        result = redash_tools.read_redash_dashboard.func(dashboard_id=1)
+
+        assert "Dashboard with Textbox" in result
+        assert "안내사항" in result
+        assert "매출 현황" in result
+        assert "Query ID 456" in result
+        assert "매출 쿼리" in result
+
     @patch("api.redash.get_query")
     def test_read_redash_query_tool(self, mock_get_query):
         """Redash 쿼리 상세 조회 tool 테스트"""


### PR DESCRIPTION
## Summary
- `read_redash_dashboard` 도구에서 textbox 위젯의 `text` 필드를 읽도록 수정
- 기존에는 `visualization` 속성이 없는 위젯(textbox)을 모두 건너뛰었으나, 이제 `text` 필드가 있는 위젯은 내용을 "텍스트" 섹션에 포함
- textbox 포함 대시보드에 대한 단위 테스트 추가

## Test plan
- [ ] 기존 `test_read_redash_dashboard_tool` 테스트 통과 확인
- [ ] 새로 추가된 `test_read_redash_dashboard_textbox` 테스트 통과 확인
- [ ] textbox만 있는 대시보드, 쿼리만 있는 대시보드, 혼합 대시보드 모두 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Notion: https://www.notion.so/team-mono/3201cc820da681b7b30dec88df8b3be7