### PR TITLE
Slack 이벤트 중복 처리 방지 (event_id dedup)

### DIFF
--- a/app/common.py
+++ b/app/common.py
@@ -24,6 +24,8 @@ def is_duplicate_event(body: dict) -> bool:
         return True
     _processed_events[event_id] = True
     return False
+
+
 from langchain_core.messages import BaseMessage, SystemMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent

--- a/app/common.py
+++ b/app/common.py
@@ -9,6 +9,21 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, Field
 
 from cachetools import TTLCache
+
+# 이벤트 중복 처리 방지용 캐시 (5분 TTL, 최대 1000개)
+# Socket Mode에서 동일 이벤트가 여러 번 전달될 수 있으므로 event_id로 중복 체크
+_processed_events: TTLCache = TTLCache(maxsize=1000, ttl=300)
+
+
+def is_duplicate_event(body: dict) -> bool:
+    """이미 처리된 이벤트인지 확인하고, 미처리 시 처리 완료로 기록합니다."""
+    event_id = body.get("event_id")
+    if not event_id:
+        return False
+    if event_id in _processed_events:
+        return True
+    _processed_events[event_id] = True
+    return False
 from langchain_core.messages import BaseMessage, SystemMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent

--- a/app/contents.py
+++ b/app/contents.py
@@ -11,6 +11,7 @@ from .common import (
     get_update_notion_task_status_tool,
     get_create_notion_follow_up_task_tool,
     get_notion_page_tool,
+    is_duplicate_event,
 )
 
 # 콘텐츠 팀 전용 노션 데이터베이스 ID
@@ -31,6 +32,9 @@ def register_contents_handlers(app_contents):
         """
         슬랙에서 콘텐츠 비서를 멘션하여 대화를 시작하면 호출되는 이벤트
         """
+        if is_duplicate_event(body):
+            return
+
         event = body.get("event")
 
         if event is None:

--- a/app/data_bot.py
+++ b/app/data_bot.py
@@ -7,7 +7,7 @@ from langchain_core.messages import BaseMessage, SystemMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
-from .common import KST, slack_users_list
+from .common import KST, slack_users_list, is_duplicate_event
 from .tool_status_handler import ToolStatusHandler
 from .tools.athena_tools import get_execute_athena_query_tool
 from .tools.chart_tools import get_execute_python_with_chart_tool
@@ -28,6 +28,9 @@ def register_data_handlers(app_data):
         """
         슬랙에서 데이터 봇을 멘션하여 데이터 분석을 시작하면 호출되는 이벤트
         """
+        if is_duplicate_event(body):
+            return
+
         event = body.get("event")
 
         if event is None:

--- a/app/general.py
+++ b/app/general.py
@@ -20,6 +20,7 @@ from .common import (
     get_update_notion_task_status_tool,
     get_create_notion_follow_up_task_tool,
     get_notion_page_tool,
+    is_duplicate_event,
 )
 
 # 상수들
@@ -45,6 +46,9 @@ def register_general_handlers(app, assistant):
         """
         슬랙에서 로봇을 멘션하여 대화를 시작하면 호출되는 이벤트
         """
+        if is_duplicate_event(body):
+            return
+
         event = body.get("event")
 
         if event is None:
@@ -98,6 +102,9 @@ def register_general_handlers(app, assistant):
         버그 신고 채널에 올라오는 메시지를 LLM으로 분석하여
         Notion에 버그 작업을 생성하고, 시급한 경우 담당 그룹을 태그합니다.
         """
+        if is_duplicate_event(body):
+            return
+
         print("Received message event:", body)
 
         event = body.get("event", {})

--- a/app/justin.py
+++ b/app/justin.py
@@ -20,7 +20,7 @@ import aiohttp
 import anthropic
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import SystemMessage, HumanMessage
-from .common import slack_users_list, notion_page_to_markdown
+from .common import slack_users_list, notion_page_to_markdown, is_duplicate_event
 from .tool_status_handler import ToolStatusHandler
 
 KST = ZoneInfo("Asia/Seoul")
@@ -166,6 +166,9 @@ def register_justin_handlers(app):
         - Notion 링크가 있으면 → 미팅 보고서 피드백
         - PDF 첨부파일이 있으면 → 제안서 피드백 (네이티브 PDF)
         """
+        if is_duplicate_event(body):
+            return
+
         event = body.get("event")
         if event is None:
             return


### PR DESCRIPTION
## Summary
- Socket Mode에서 동일 이벤트가 여러 번 전달될 때 중복 응답하는 버그 수정
- `common.py`에 `is_duplicate_event()` 함수 추가 — `TTLCache(maxsize=1000, ttl=300)`로 `event_id` 추적
- 모든 봇 핸들러(general, contents, data_bot, justin)의 이벤트 처리 시작 부분에 중복 체크 적용

## Context
데이터봇에 1번 멘션했는데 3번 응답하는 버그 신고 ([Slack 스레드](https://monolith-keb2010.slack.com/archives/C0AHU2XDBT2/p1773278317727779))

## Test plan
- [ ] 데이터봇 멘션 시 1번만 응답하는지 확인
- [ ] 다른 봇(범용, 콘텐츠, Justin)도 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)