### PR TITLE
Fix ToolStatusHandler race condition on parallel tool calls

### DIFF
--- a/app/tool_status_handler.py
+++ b/app/tool_status_handler.py
@@ -36,10 +36,6 @@ class ToolStatusHandler(BaseCallbackHandler):
             []
         )  # 실행된 툴 이력: {"run_id": str, "name": str, "params": str, "status": str}
         self._lock = None  # 동시성 제어를 위한 lock (lazy init)
-        self._message_created_event = (
-            None  # 첫 메시지 생성 완료 대기용 Event (lazy init)
-        )
-        self._creating_message = False  # 첫 메시지 생성 중 플래그
         self.langsmith_run_id = None  # LangSmith trace의 최상위 run_id
 
     @property
@@ -48,13 +44,6 @@ class ToolStatusHandler(BaseCallbackHandler):
         if self._lock is None:
             self._lock = asyncio.Lock()
         return self._lock
-
-    @property
-    def message_created_event(self):
-        """현재 event loop에서 Event를 lazy하게 생성"""
-        if self._message_created_event is None:
-            self._message_created_event = asyncio.Event()
-        return self._message_created_event
 
     def _format_status_text(self) -> str:
         """
@@ -151,7 +140,6 @@ class ToolStatusHandler(BaseCallbackHandler):
         tool_name = serialized["name"]
         run_id = kwargs.get("run_id")  # 툴 실행의 고유 ID
 
-        # Lock 안에서 tool_history 수정 및 역할 결정
         async with self.lock:
             self.tool_history.append(
                 {
@@ -164,55 +152,35 @@ class ToolStatusHandler(BaseCallbackHandler):
 
             status_text = self._format_status_text()
 
-            if self.status_message_ts is not None:
-                # 이미 메시지가 존재 → 업데이트
-                role = "update"
-            elif self._creating_message:
-                # 다른 코루틴이 메시지 생성 중 → 대기 후 업데이트
-                role = "wait_then_update"
-            else:
-                # 첫 번째 코루틴 → 메시지 생성 담당
-                self._creating_message = True
-                role = "create"
-
-        # Lock 밖에서 Slack API 호출
-        if role == "create":
-            response = await self.say(
-                {
-                    "blocks": [
-                        {
-                            "type": "section",
-                            "text": {"type": "mrkdwn", "text": status_text},
-                            "expand": False,
-                        }
-                    ]
-                },
-                thread_ts=self.thread_ts,
-            )
-            async with self.lock:
-                self.status_message_ts = response.get("ts")
-            # 대기 중인 코루틴들에게 메시지 생성 완료를 알림
-            self.message_created_event.set()
-        else:
-            if role == "wait_then_update":
-                # 첫 메시지 생성이 완료될 때까지 대기
-                await self.message_created_event.wait()
-                # 대기 후 최신 상태로 다시 포맷팅
-                async with self.lock:
-                    status_text = self._format_status_text()
-
-            # 기존 메시지 업데이트
-            await self.slack_client.chat_update(
-                channel=self.channel,
-                ts=self.status_message_ts,
-                blocks=[
+            if self.status_message_ts is None:
+                # 첫 메시지 생성: lock을 유지하여 중복 방지
+                response = await self.say(
                     {
-                        "type": "section",
-                        "text": {"type": "mrkdwn", "text": status_text},
-                        "expand": False,
-                    }
-                ],
-            )
+                        "blocks": [
+                            {
+                                "type": "section",
+                                "text": {"type": "mrkdwn", "text": status_text},
+                                "expand": False,
+                            }
+                        ]
+                    },
+                    thread_ts=self.thread_ts,
+                )
+                self.status_message_ts = response.get("ts")
+                return
+
+        # Lock 밖에서 기존 메시지 업데이트
+        await self.slack_client.chat_update(
+            channel=self.channel,
+            ts=self.status_message_ts,
+            blocks=[
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": status_text},
+                    "expand": False,
+                }
+            ],
+        )
 
     async def on_tool_end(
         self,

--- a/app/tool_status_handler.py
+++ b/app/tool_status_handler.py
@@ -36,7 +36,9 @@ class ToolStatusHandler(BaseCallbackHandler):
             []
         )  # 실행된 툴 이력: {"run_id": str, "name": str, "params": str, "status": str}
         self._lock = None  # 동시성 제어를 위한 lock (lazy init)
-        self._message_created_event = None  # 첫 메시지 생성 완료 대기용 Event (lazy init)
+        self._message_created_event = (
+            None  # 첫 메시지 생성 완료 대기용 Event (lazy init)
+        )
         self._creating_message = False  # 첫 메시지 생성 중 플래그
         self.langsmith_run_id = None  # LangSmith trace의 최상위 run_id
 

--- a/app/tool_status_handler.py
+++ b/app/tool_status_handler.py
@@ -36,6 +36,8 @@ class ToolStatusHandler(BaseCallbackHandler):
             []
         )  # 실행된 툴 이력: {"run_id": str, "name": str, "params": str, "status": str}
         self._lock = None  # 동시성 제어를 위한 lock (lazy init)
+        self._message_created_event = None  # 첫 메시지 생성 완료 대기용 Event (lazy init)
+        self._creating_message = False  # 첫 메시지 생성 중 플래그
         self.langsmith_run_id = None  # LangSmith trace의 최상위 run_id
 
     @property
@@ -44,6 +46,13 @@ class ToolStatusHandler(BaseCallbackHandler):
         if self._lock is None:
             self._lock = asyncio.Lock()
         return self._lock
+
+    @property
+    def message_created_event(self):
+        """현재 event loop에서 Event를 lazy하게 생성"""
+        if self._message_created_event is None:
+            self._message_created_event = asyncio.Event()
+        return self._message_created_event
 
     def _format_status_text(self) -> str:
         """
@@ -140,7 +149,7 @@ class ToolStatusHandler(BaseCallbackHandler):
         tool_name = serialized["name"]
         run_id = kwargs.get("run_id")  # 툴 실행의 고유 ID
 
-        # Lock 안에서는 tool_history만 수정
+        # Lock 안에서 tool_history 수정 및 역할 결정
         async with self.lock:
             self.tool_history.append(
                 {
@@ -152,10 +161,20 @@ class ToolStatusHandler(BaseCallbackHandler):
             )
 
             status_text = self._format_status_text()
-            is_first_message = self.status_message_ts is None
+
+            if self.status_message_ts is not None:
+                # 이미 메시지가 존재 → 업데이트
+                role = "update"
+            elif self._creating_message:
+                # 다른 코루틴이 메시지 생성 중 → 대기 후 업데이트
+                role = "wait_then_update"
+            else:
+                # 첫 번째 코루틴 → 메시지 생성 담당
+                self._creating_message = True
+                role = "create"
 
         # Lock 밖에서 Slack API 호출
-        if is_first_message:
+        if role == "create":
             response = await self.say(
                 {
                     "blocks": [
@@ -168,11 +187,18 @@ class ToolStatusHandler(BaseCallbackHandler):
                 },
                 thread_ts=self.thread_ts,
             )
-            # say() 응답에서 ts 저장
             async with self.lock:
-                if self.status_message_ts is None:  # 다시 체크 (race condition 방지)
-                    self.status_message_ts = response.get("ts")
+                self.status_message_ts = response.get("ts")
+            # 대기 중인 코루틴들에게 메시지 생성 완료를 알림
+            self.message_created_event.set()
         else:
+            if role == "wait_then_update":
+                # 첫 메시지 생성이 완료될 때까지 대기
+                await self.message_created_event.wait()
+                # 대기 후 최신 상태로 다시 포맷팅
+                async with self.lock:
+                    status_text = self._format_status_text()
+
             # 기존 메시지 업데이트
             await self.slack_client.chat_update(
                 channel=self.channel,


### PR DESCRIPTION
## Summary
- 병렬 tool call 시 `ToolStatusHandler.on_tool_start()`에서 여러 코루틴이 동시에 `say()`를 호출하여 중복 메시지가 생성되는 race condition 수정
- `_creating_message` 플래그와 `asyncio.Event`를 사용하여 첫 번째 코루틴만 메시지를 생성하고, 나머지는 생성 완료를 기다린 후 `chat_update`로 업데이트하도록 변경
- 기존 PR #57 (이벤트 중복 처리 방지)은 잘못된 진단이었으므로 close 처리

## Test plan
- [ ] 데이터봇에 병렬 tool call을 유발하는 질의 전송 (예: 여러 테이블 조회 필요한 분석 요청)
- [ ] 스레드에 진행 상태 메시지가 1개만 생성되는지 확인
- [ ] 모든 tool call의 상태(⏳/✅/❌)가 하나의 메시지에서 올바르게 업데이트되는지 확인

Notion: https://www.notion.so/team-mono/3211cc820da68122a6ade1ed80d6eb82

🤖 Generated with [Claude Code](https://claude.com/claude-code)