### PR TITLE
5일 후 공휴일/주말인 경우 로드맵 알림 제외

### DIFF
--- a/scripts/manage_tasks_daily.py
+++ b/scripts/manage_tasks_daily.py
@@ -14,6 +14,7 @@ from notion_client import Client as NotionClient
 from openai import OpenAI
 from slack_sdk import WebClient
 
+from service.business_days import is_business_day
 from service.holidays import get_public_holidays
 from service.slack import get_email_to_user_id
 
@@ -468,6 +469,10 @@ def alert_no_upcoming_tasks(
 
     # 5일 후 날짜 계산
     target_date = (datetime.now() + timedelta(days=5)).date()
+
+    # 5일 후가 공휴일이나 주말이면 알림 건너뛰기
+    if not is_business_day(target_date):
+        return
 
     # 5일 후에 진행 중일 것으로 예상되는 작업들을 찾습니다.
     # 시작일 <= 5일 후 AND 종료일 >= 5일 후 AND 상태가 완료/보류가 아닌 작업


### PR DESCRIPTION
## Summary
- `alert_no_upcoming_tasks`에서 5일 후 날짜가 공휴일이나 주말이면 알림을 건너뛰도록 처리
- 기존 `is_business_day` 유틸리티를 활용하여 공휴일/주말 여부 판단
- 공휴일에 작업이 없는 것은 정상이므로 불필요한 알림 방지

## Context
- Slack 요청: 공휴일에는 작업이 없을 수 있으므로 알림 제외 요청
- Notion: https://www.notion.so/team-mono/5-3261cc820da681929636d410aa4ce70d

## Test plan
- [ ] 공휴일 날짜로 테스트 시 알림이 발송되지 않는지 확인
- [ ] 평일 날짜로 테스트 시 기존과 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)