### PR TITLE
로드맵 점검 알림을 영업일 기준 5일 후로 변경

### DIFF
--- a/scripts/manage_tasks_daily.py
+++ b/scripts/manage_tasks_daily.py
@@ -14,6 +14,7 @@ from notion_client import Client as NotionClient
 from openai import OpenAI
 from slack_sdk import WebClient
 
+from service.business_days import get_nth_business_day_from
 from service.holidays import get_public_holidays
 from service.slack import get_email_to_user_id
 
@@ -466,8 +467,8 @@ def alert_no_upcoming_tasks(
     # 예진님 Slack ID
     YEJIN_SLACK_ID = "U075PUFNGHX"
 
-    # 5일 후 날짜 계산
-    target_date = (datetime.now() + timedelta(days=5)).date()
+    # 영업일 기준 5일 후 날짜 계산
+    target_date = get_nth_business_day_from(datetime.now().date(), 5)
 
     # 5일 후에 진행 중일 것으로 예상되는 작업들을 찾습니다.
     # 시작일 <= 5일 후 AND 종료일 >= 5일 후 AND 상태가 완료/보류가 아닌 작업

--- a/service/business_days.py
+++ b/service/business_days.py
@@ -121,6 +121,46 @@ def get_business_days_in_range(
     return business_days
 
 
+def get_nth_business_day_from(
+    start_date: date,
+    n: int,
+    exclude_holidays: bool = True,
+) -> date:
+    """
+    시작일로부터 n번째 영업일 날짜를 반환
+
+    Args:
+        start_date: 시작 날짜 (포함하지 않음)
+        n: 영업일 수
+        exclude_holidays: True면 공휴일도 제외
+
+    Returns:
+        date: n번째 영업일 날짜
+    """
+    holidays_cache: dict[tuple[int, int], set[str]] = {}
+
+    def get_holidays_cached(year: int, month: int) -> set[str]:
+        key = (year, month)
+        if key not in holidays_cache:
+            holidays_cache[key] = get_public_holidays(year, month)
+        return holidays_cache[key]
+
+    count = 0
+    current_date = start_date
+
+    while count < n:
+        current_date += timedelta(days=1)
+        if current_date.weekday() < 5:
+            if exclude_holidays:
+                holidays = get_holidays_cached(current_date.year, current_date.month)
+                if current_date.isoformat() not in holidays:
+                    count += 1
+            else:
+                count += 1
+
+    return current_date
+
+
 def count_business_days_in_month(
     year: int,
     month: int,


### PR DESCRIPTION
## Summary
- 로드맵 점검 알림의 "5일 후" 계산을 달력 기준에서 영업일 기준으로 변경
- `service/business_days.py`에 `get_nth_business_day_from()` 함수 추가
- 주말과 공휴일을 건너뛰고 5번째 영업일을 타겟으로 사용

## Test plan
- [ ] 금요일에 실행 시 다음주 금요일이 타겟 날짜인지 확인
- [ ] 공휴일 포함 주에 올바른 날짜 계산 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)