### PR TITLE
로드맵 알림 메시지에 실제 날짜/요일 표시 개선

### DIFF
--- a/scripts/manage_tasks_daily.py
+++ b/scripts/manage_tasks_daily.py
@@ -564,8 +564,10 @@ def alert_no_upcoming_tasks(
                 member_mentions.append(email)
 
         members_text = ", ".join(member_mentions)
+        weekday_names = ["월", "화", "수", "목", "금", "토", "일"]
+        target_weekday = weekday_names[target_date.weekday()]
         text = (
-            f"<@{YEJIN_SLACK_ID}> 5일 후에 예정된 작업이 없는 멤버가 있습니다: {members_text}\n"
+            f"<@{YEJIN_SLACK_ID}> 5일 후 {target_date.month}/{target_date.day}({target_weekday})에 예정된 작업이 없는 멤버가 있습니다: {members_text}\n"
             "로드맵 점검 부탁드립니다."
         )
         slack_client.chat_postMessage(channel=channel_id, text=text)


### PR DESCRIPTION
## Summary
- 로드맵 점검 알림 메시지에서 "5일 후에 예정된 작업이 없는 멤버가 있습니다"를 "5일 후 3/22(일)에 예정된 작업이 없는 멤버가 있습니다" 형식으로 개선
- 알림 수신자가 구체적인 날짜를 바로 파악할 수 있도록 함

## Test plan
- [ ] 로컬에서 `alert_no_upcoming_tasks` 함수 호출 시 날짜/요일이 정확히 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Notion: https://www.notion.so/3261cc820da6816bb8caf052202bebd2