### PR TITLE
근무 현황 표에서 특정 인원 제외

### DIFF
--- a/scripts/notify_worktime_left.py
+++ b/scripts/notify_worktime_left.py
@@ -26,6 +26,16 @@ load_dotenv()
 CHANNEL_ID: str = "C08EUJJSZF1"
 REQUIRED_DAILY_MINUTES = 8 * 60  # 하루 근무시간(480분)
 
+# 근무 현황 표에서 제외할 이름 목록
+EXCLUDED_NAMES: set[str] = {
+    "David Eom",
+    "고려대학교 HPIC 연구원",
+    "엄은상",
+    "자흐라",
+    "이의찬",
+    "류승찬",
+}
+
 
 def main():
     """
@@ -87,6 +97,8 @@ def main():
         user_info = user_id_to_user_info.get(user_id, {})
         real_name = user_info.get("real_name", "")
         if not real_name:
+            continue
+        if real_name in EXCLUDED_NAMES:
             continue
 
         # 이미 근무한 시간(분)


### PR DESCRIPTION
## Summary
- 근무 현황(간소화) 표에서 David Eom, 고려대학교 HPIC 연구원, 엄은상, 자흐라, 이의찬, 류승찬을 제외
- `EXCLUDED_NAMES` 상수로 제외 목록을 관리하여 유지보수 용이

## Test plan
- [ ] `--dry-run` 모드로 실행하여 제외 대상이 표에 나타나지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)