### PR TITLE
feat: 5일 후 작업 없는 멤버 알림에서 종일 연차자 제외

### DIFF
--- a/scripts/manage_tasks_daily.py
+++ b/scripts/manage_tasks_daily.py
@@ -14,6 +14,7 @@ from notion_client import Client as NotionClient
 from openai import OpenAI
 from slack_sdk import WebClient
 
+from api.wantedspace import get_workevent
 from service.business_days import get_nth_business_day_from
 from service.holidays import get_public_holidays
 from service.slack import get_email_to_user_id
@@ -551,8 +552,21 @@ def alert_no_upcoming_tasks(
         if email:
             team_emails.append(email)
 
-    # 5일 후에 예정된 작업이 없는 멤버 찾기
-    unassigned_emails = set(team_emails) - assigned_emails
+    # 5일 후 당일 종일 연차인 멤버 제외
+    target_date_str = target_date.isoformat()
+    workevent = get_workevent(date=target_date_str, type="day")
+    vacation_days_by_email: dict[str, float] = defaultdict(float)
+    for ev in workevent.get("results", []):
+        email = ev.get("email")
+        counted = float(ev.get("wk_counted_days", 0.0))
+        if email and counted > 0:
+            vacation_days_by_email[email] += counted
+    on_leave_emails = {
+        email for email, days in vacation_days_by_email.items() if days >= 1.0
+    }
+
+    # 5일 후에 예정된 작업이 없는 멤버 찾기 (연차자 제외)
+    unassigned_emails = set(team_emails) - assigned_emails - on_leave_emails
 
     # 예진님에게 알림 보내기
     if unassigned_emails:


### PR DESCRIPTION
## Summary
- 5일 후 당일에 종일 연차인 멤버를 알림 대상에서 제외
- 원티드스페이스 workevent API로 해당 일자의 휴가 정보를 조회하여 `wk_counted_days` 합산이 1.0 이상인 멤버를 필터링
- 반차(0.5일)는 작업 가능하므로 제외하지 않음

## Test plan
- [ ] 종일 연차자가 알림에서 제외되는지 확인
- [ ] 반차자는 알림에 포함되는지 확인
- [ ] 연차자가 없는 경우 기존 동작과 동일한지 확인

Slack 요청: https://team-monolith-product.slack.com/archives/C087PDC9VG8/p1774223563755859

🤖 Generated with [Claude Code](https://claude.com/claude-code)