### PR TITLE
배포 예정 과업 목록에서 closed PR 제외

### DIFF
--- a/app/summarize_deployment.py
+++ b/app/summarize_deployment.py
@@ -45,7 +45,7 @@ SLACK_CHANNEL_ID: str = "C02VA2LLXH9"
 def get_pr_links(
     notion: NotionClient, pr_relations: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
-    """PR 관계 속성에서 PR 링크들과 병합 상태를 추출합니다."""
+    """PR 관계 속성에서 PR 링크들과 병합 상태를 추출합니다. closed(미병합) PR은 제외합니다."""
     pr_links_info: list[dict[str, Any]] = []
     for relation in pr_relations:
         pr_page_id: str = relation["id"]
@@ -57,11 +57,19 @@ def get_pr_links(
             pr_url: str = url_property["url"]
             # 'Merged At' 필드에서 병합 여부 추출
             merged_at_property: dict[str, Any] = properties.get("Merged At", {})
-            is_merged: bool = False
-            if merged_at_property.get("date") and merged_at_property["date"].get(
-                "start"
-            ):
-                is_merged = True
+            is_merged: bool = bool(
+                merged_at_property.get("date")
+                and merged_at_property["date"].get("start")
+            )
+            # 'Closed At' 필드에서 종료 여부 추출
+            closed_at_property: dict[str, Any] = properties.get("Closed At", {})
+            is_closed: bool = bool(
+                closed_at_property.get("date")
+                and closed_at_property["date"].get("start")
+            )
+            # closed이면서 미병합인 PR은 제외
+            if is_closed and not is_merged:
+                continue
             pr_links_info.append({"url": pr_url, "merged": is_merged})
         else:
             # URL 속성이 없는 경우 처리 로직을 추가할 수 있습니다.


### PR DESCRIPTION
## Summary
- 배포 예정 과업 목록(`summarize_deployment`)에서 closed(미병합) PR을 제외하도록 필터링 추가
- `Closed At`이 설정되어 있고 `Merged At`이 없는 PR은 목록에서 제외
- open PR과 merged PR은 기존과 동일하게 표시

## Notion Task
[AHA-40 — 배포 예정 과업 목록에서 closed PR 제외](https://www.notion.so/team-mono/32d1cc820da681e19b6aed3af5999cfa)

## Slack Thread
https://team-monolith-product.slack.com/archives/C02VA2LLXH9/p1774338756576839

## Test plan
- [ ] closed(미병합) PR이 있는 과업에서 해당 PR이 목록에서 제외되는지 확인
- [ ] merged PR은 기존대로 ✅ 표시되는지 확인
- [ ] open PR은 기존대로 ❌ 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)