### PR TITLE
refactor: 스크럼 설정을 선언형 YAML config로 전환

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ pandas
 matplotlib
 anthropic
 sentry-sdk[fastapi]
+PyYAML

--- a/scripts/post_scrum_message.py
+++ b/scripts/post_scrum_message.py
@@ -9,7 +9,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import argparse
 import os
-from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
@@ -18,48 +17,16 @@ from notion_client import Client as NotionClient
 from slack_sdk import WebClient
 
 from service.business_days import count_business_days
+from service.scrum_config import (
+    NotionDBConfig,
+    PersonalScrum,
+    ScrumSquad,
+    load_scrum_config,
+)
 from service.slack import get_email_to_user_id
-from service.teams import ALL_TEAM_USERGROUP_IDS
 
 # 환경 변수 로드
 load_dotenv()
-
-# 상수 정의
-SCRUM_CHANNEL_ID = "C09277NGUET"
-
-USER_CHANGWHAN = "U02HT4EU4VD"
-
-
-@dataclass(frozen=True)
-class NotionDBConfig:
-    """Notion DB별 프로퍼티 매핑 설정"""
-
-    data_source_id: str
-    title_property: str
-    status_property: str
-    in_progress_statuses: list[str] = field(default_factory=list)
-    assignee_property: str = "담당자"
-    date_property: str = "타임라인"
-    pr_property: str | None = "GitHub 풀 리퀘스트"
-
-
-MAIN_DB_CONFIG = NotionDBConfig(
-    data_source_id="3e050c5a-11f3-4a3e-b6d0-498fe06c9d7b",
-    title_property="제목",
-    status_property="상태",
-    in_progress_statuses=["진행", "리뷰"],
-    date_property="타임라인",
-    pr_property="GitHub 풀 리퀘스트",
-)
-
-EXPLORE_DB_CONFIG = NotionDBConfig(
-    data_source_id="3141cc82-0da6-8103-913c-000ba234b439",
-    title_property="작업",
-    status_property="진행 상태",
-    in_progress_statuses=["진행 중", "테스트 중"],
-    date_property="마감일",
-    pr_property=None,
-)
 
 
 def main():
@@ -72,6 +39,8 @@ def main():
     )
     args = parser.parse_args()
 
+    config = load_scrum_config()
+
     notion = NotionClient(
         auth=os.environ.get("NOTION_TOKEN"), notion_version="2025-09-03"
     )
@@ -82,49 +51,37 @@ def main():
 
     if args.dry_run:
         print("=== DRY RUN MODE ===")
-        print(f"채널: {SCRUM_CHANNEL_ID}\n")
+        print(f"채널: {config.channel_id}\n")
 
     # 1. 안내 메시지 발송
-    send_intro_message(slack_client, args.dry_run)
+    send_intro_message(slack_client, config.channel_id, args.dry_run)
 
-    # 2. 기획팀 스크럼
-    send_team_scrum(
-        notion, slack_client, email_to_user_id, "기획", "기획", args.dry_run
-    )
+    # 2. 스쿼드별 스크럼
+    for squad in config.squads:
+        send_team_scrum(
+            notion,
+            slack_client,
+            email_to_user_id,
+            squad,
+            config.channel_id,
+            args.dry_run,
+        )
 
-    # 3. FE팀 스크럼
-    send_team_scrum(notion, slack_client, email_to_user_id, "fe", "FE", args.dry_run)
-
-    # 4. BE팀 스크럼
-    send_team_scrum(notion, slack_client, email_to_user_id, "be", "BE", args.dry_run)
-
-    # 5. IE팀 스크럼
-    send_team_scrum(notion, slack_client, email_to_user_id, "ie", "IE", args.dry_run)
-
-    # 6. 탐색팀 스크럼
-    send_team_scrum(
-        notion,
-        slack_client,
-        email_to_user_id,
-        "탐색",
-        "탐색",
-        args.dry_run,
-        db_config=EXPLORE_DB_CONFIG,
-    )
-
-    # 7. 이창환 스크럼
-    send_personal_scrum(slack_client, args.dry_run)
+    # 3. 개인 스크럼
+    for personal in config.personal_scrums:
+        send_personal_scrum(slack_client, personal, config.channel_id, args.dry_run)
 
     if args.dry_run:
         print("\n=== DRY RUN COMPLETED ===")
 
 
-def send_intro_message(slack_client: WebClient, dry_run: bool = False):
+def send_intro_message(slack_client: WebClient, channel_id: str, dry_run: bool = False):
     """
     안내 메시지 발송
 
     Args:
         slack_client: Slack WebClient
+        channel_id: 스크럼 채널 ID
         dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
     """
     intro_text = "오늘 스크럼을 시작합니다. 4:40까지 작성 부탁드립니다!"
@@ -152,14 +109,14 @@ def send_intro_message(slack_client: WebClient, dry_run: bool = False):
     else:
         # 메인 메시지 발송
         response = slack_client.chat_postMessage(
-            channel=SCRUM_CHANNEL_ID,
+            channel=channel_id,
             text=intro_text,
         )
 
         # 스레드에 상세 안내 추가
         thread_ts = response["ts"]
         slack_client.chat_postMessage(
-            channel=SCRUM_CHANNEL_ID,
+            channel=channel_id,
             thread_ts=thread_ts,
             text=detail_text,
         )
@@ -169,10 +126,9 @@ def send_team_scrum(
     notion: NotionClient,
     slack_client: WebClient,
     email_to_user_id: dict[str, str],
-    team_handle: str,
-    team_name: str,
+    squad: ScrumSquad,
+    channel_id: str,
     dry_run: bool = False,
-    db_config: NotionDBConfig = MAIN_DB_CONFIG,
 ):
     """
     팀별 스크럼 메시지 발송 (Notion에서 진행 중인 태스크 조회)
@@ -181,26 +137,25 @@ def send_team_scrum(
         notion: Notion Client
         slack_client: Slack WebClient
         email_to_user_id: 이메일 -> Slack User ID 매핑
-        team_handle: 팀 핸들 (예: "fe", "be", "ie")
-        team_name: 팀 이름 (예: "FE", "BE", "IE")
+        squad: 스쿼드 설정
+        channel_id: 스크럼 채널 ID
         dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
-        db_config: Notion DB 설정 (기본값: MAIN_DB_CONFIG)
     """
     # 메인 메시지
-    text = f"{team_name}팀 스크럼"
+    text = f"{squad.display_name}팀 스크럼"
 
     if dry_run:
-        print(f"\n[{team_name}팀 스크럼]")
+        print(f"\n[{squad.display_name}팀 스크럼]")
         print(text)
 
     # 팀 멤버의 진행 중인 태스크 조회
-    team_members = get_team_members(slack_client, team_handle)
+    team_members = get_team_members(slack_client, squad.slack_usergroup_id)
     team_emails = [
         email for email, user_id in email_to_user_id.items() if user_id in team_members
     ]
 
     # Notion에서 진행 중인 태스크 조회
-    in_progress_tasks = get_in_progress_tasks(notion, team_emails, db_config)
+    in_progress_tasks = get_in_progress_tasks(notion, team_emails, squad.notion_db)
 
     # 이메일별로 태스크 그룹화
     email_to_tasks = {}
@@ -219,12 +174,15 @@ def send_team_scrum(
         # 담당자 이름 (첫 번째 태스크에서 가져옴)
         assignee_name = tasks[0]["assignee_name"]
 
+        # PR 경고 활성화 여부
+        pr_warning_enabled = (
+            squad.pr_warning and squad.notion_db.properties.pr is not None
+        )
+
         # 인원별 메시지 생성
         person_message = f"{assignee_name}\n"
-        # PR 경고 비활성화 여부 (기획팀이거나 PR 프로퍼티가 없는 DB)
-        is_planning_team = team_handle == "기획" or db_config.pr_property is None
         for task in tasks:
-            task_line = format_task_line(task, is_planning_team)
+            task_line = format_task_line(task, pr_warning_enabled)
             person_message += f"{task_line}\n"
 
         thread_messages.append(person_message.strip())
@@ -239,7 +197,7 @@ def send_team_scrum(
     else:
         # 실제 메시지 발송
         response = slack_client.chat_postMessage(
-            channel=SCRUM_CHANNEL_ID,
+            channel=channel_id,
             text=text,
         )
         thread_ts = response["ts"]
@@ -247,61 +205,62 @@ def send_team_scrum(
         # 인원별 메시지를 스레드에 발송
         for msg in thread_messages:
             slack_client.chat_postMessage(
-                channel=SCRUM_CHANNEL_ID,
+                channel=channel_id,
                 thread_ts=thread_ts,
                 text=msg,
             )
 
 
-def send_personal_scrum(slack_client: WebClient, dry_run: bool = False):
+def send_personal_scrum(
+    slack_client: WebClient,
+    personal: PersonalScrum,
+    channel_id: str,
+    dry_run: bool = False,
+):
     """
-    이창환 개인 스크럼 메시지 발송
+    개인 스크럼 메시지 발송
 
     Args:
         slack_client: Slack WebClient
+        personal: 개인 스크럼 설정
+        channel_id: 스크럼 채널 ID
         dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
     """
-    text = "이창환 스크럼"
+    text = f"{personal.name} 스크럼"
 
     if dry_run:
-        print(f"\n[이창환 스크럼]")
+        print(f"\n[{personal.name} 스크럼]")
         print(text)
     else:
         slack_client.chat_postMessage(
-            channel=SCRUM_CHANNEL_ID,
+            channel=channel_id,
             text=text,
         )
 
 
-def get_team_members(slack_client: WebClient, team_handle: str) -> list[str]:
+def get_team_members(slack_client: WebClient, slack_usergroup_id: str) -> list[str]:
     """
-    팀 핸들로 팀 멤버의 Slack User ID 목록 조회
+    Slack 사용자 그룹 ID로 팀 멤버의 Slack User ID 목록 조회
 
     Args:
         slack_client: Slack WebClient
-        team_handle: 팀 핸들 (예: "fe", "be", "ie")
+        slack_usergroup_id: Slack 사용자 그룹 ID
 
     Returns:
         list[str]: Slack User ID 목록
     """
-    # 사용자 그룹 ID 조회
-    group_id = ALL_TEAM_USERGROUP_IDS.get(team_handle)
-    if not group_id:
-        return []
-
-    # 그룹 멤버 조회
     try:
-        response = slack_client.usergroups_users_list(usergroup=group_id)
+        response = slack_client.usergroups_users_list(usergroup=slack_usergroup_id)
         return response.get("users", [])
     except Exception as e:
-        print(f"Error fetching team members for {team_handle}: {e}")
+        print(f"Error fetching team members for {slack_usergroup_id}: {e}")
         return []
 
 
 def get_in_progress_tasks(
     notion: NotionClient,
     team_emails: list[str],
-    db_config: NotionDBConfig = MAIN_DB_CONFIG,
+    db_config: NotionDBConfig,
 ) -> list[dict[str, Any]]:
     """
     Notion에서 팀 멤버들의 진행 중인 태스크 조회
@@ -314,9 +273,9 @@ def get_in_progress_tasks(
     Returns:
         list[dict]: 태스크 정보 목록
     """
-    # 진행 중 상태의 태스크 조회 (DB별 상태값 사용)
+    # 진행 중 상태의 태스크 조회
     status_filters = [
-        {"property": db_config.status_property, "status": {"equals": status}}
+        {"property": db_config.properties.status, "status": {"equals": status}}
         for status in db_config.in_progress_statuses
     ]
     results = notion.data_sources.query(
@@ -329,7 +288,7 @@ def get_in_progress_tasks(
     tasks = []
     for result in results.get("results", []):
         # 담당자 확인
-        people = result["properties"][db_config.assignee_property].get("people", [])
+        people = result["properties"][db_config.properties.assignee].get("people", [])
         if not people:
             continue
 
@@ -343,13 +302,13 @@ def get_in_progress_tasks(
 
         # 태스크 정보 추출
         try:
-            title_prop = result["properties"][db_config.title_property]["title"]
+            title_prop = result["properties"][db_config.properties.title]["title"]
             title = title_prop[0]["text"]["content"] if title_prop else "제목 없음"
         except (KeyError, IndexError):
             title = "제목 없음"
 
         # 마감일
-        date_value = result["properties"][db_config.date_property].get("date")
+        date_value = result["properties"][db_config.properties.timeline].get("date")
         deadline = (
             date_value["end"]
             if date_value and date_value.get("end")
@@ -358,8 +317,8 @@ def get_in_progress_tasks(
 
         # GitHub PR 연결 여부
         has_pr = False
-        if db_config.pr_property:
-            github_prs = result["properties"][db_config.pr_property]["relation"]
+        if db_config.properties.pr:
+            github_prs = result["properties"][db_config.properties.pr]["relation"]
             has_pr = len(github_prs) > 0
 
         # 담당자 이름
@@ -379,13 +338,13 @@ def get_in_progress_tasks(
     return tasks
 
 
-def format_task_line(task: dict[str, Any], is_planning_team: bool = False) -> str:
+def format_task_line(task: dict[str, Any], pr_warning_enabled: bool = True) -> str:
     """
     태스크 정보를 한 줄 형식으로 포맷팅 (인원별 그룹화에 사용)
 
     Args:
         task: 태스크 정보
-        is_planning_team: 기획팀 여부 (True인 경우 PR 경고 표시 안 함)
+        pr_warning_enabled: PR 경고 표시 여부
 
     Returns:
         str: 포맷팅된 한 줄 메시지
@@ -410,8 +369,8 @@ def format_task_line(task: dict[str, Any], is_planning_team: bool = False) -> st
         else:
             deadline_text = f" 마감일 지남 ({abs(days_until_deadline)}일)."
 
-        # PR 없음 경고 (마감 1일 전 또는 당일, 기획팀 제외)
-        if days_until_deadline <= 1 and not task["has_pr"] and not is_planning_team:
+        # PR 없음 경고 (마감 1일 전 또는 당일, PR 경고 활성화된 경우)
+        if days_until_deadline <= 1 and not task["has_pr"] and pr_warning_enabled:
             warning_text = " PR이 없으므로 일정 조정이 필요합니다."
 
     # 메시지 포맷

--- a/scripts/schedule_scrum_mention.py
+++ b/scripts/schedule_scrum_mention.py
@@ -13,29 +13,25 @@ import time
 from dotenv import load_dotenv
 from slack_sdk import WebClient
 
-from service.teams import get_team_mention
+from service.scrum_config import load_scrum_config
 
 # 환경 변수 로드
 load_dotenv()
-
-SCRUM_CHANNEL_ID = "C09277NGUET"
-
-# 팀별 멘션 그룹 ID (service.teams에서 가져온 값 + 개인)
-TEAM_MENTIONS = {
-    "기획": get_team_mention("기획"),
-    "FE": get_team_mention("fe"),
-    "BE": get_team_mention("be"),
-    "IE": get_team_mention("ie"),
-    "탐색": get_team_mention("탐색"),
-    "이창환": "<@U02HT4EU4VD>",
-}
 
 
 def main():
     """메인 함수"""
     print("=== 스크럼 멘션 스케줄러 시작 ===")
 
+    config = load_scrum_config()
     slack_client = WebClient(token=os.environ.get("SLACK_BOT_TOKEN"))
+
+    # config에서 팀별 멘션 구성
+    team_mentions = {}
+    for squad in config.squads:
+        team_mentions[squad.display_name] = f"<!subteam^{squad.slack_usergroup_id}>"
+    for personal in config.personal_scrums:
+        team_mentions[personal.name] = f"<@{personal.slack_user_id}>"
 
     # 16:00에 보낸 스크럼 메시지 찾기 (최근 2시간 이내)
     now = time.time()
@@ -45,14 +41,14 @@ def main():
     print(
         f"검색 시작 시간: {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(oldest))}"
     )
-    print(f"채널 ID: {SCRUM_CHANNEL_ID}")
+    print(f"채널 ID: {config.channel_id}")
 
     try:
         # 채널의 최근 메시지 조회
         # Slack API는 oldest를 정수 형태의 문자열로 전달해야 함
         print("\n메시지 조회 중...")
         response = slack_client.conversations_history(
-            channel=SCRUM_CHANNEL_ID,
+            channel=config.channel_id,
             oldest=str(int(oldest)),  # float를 int로 변환 후 문자열로
             limit=50,
         )
@@ -71,8 +67,8 @@ def main():
             print(f"\n[메시지 {idx}] 시간: {msg_time}")
             print(f"텍스트: {text[:100]}{'...' if len(text) > 100 else ''}")
 
-            # 팀별 스크럼 메시지 매칭 (타임스탬프 제거됨)
-            for team_name in ["기획", "FE", "BE", "IE", "탐색", "이창환"]:
+            # 팀별 스크럼 메시지 매칭
+            for team_name in team_mentions:
                 if f"{team_name}팀 스크럼" in text or f"{team_name} 스크럼" in text:
                     team_threads[team_name] = message["ts"]
                     print(f"✓ {team_name} 팀 스레드 발견 (ts: {ts})")
@@ -86,7 +82,7 @@ def main():
         # 각 팀 스레드에 멘션 답글 추가
         print("\n=== 멘션 발송 시작 ===")
         for team_name, thread_ts in team_threads.items():
-            mention = TEAM_MENTIONS.get(team_name)
+            mention = team_mentions.get(team_name)
             if mention:
                 reply_text = f"{mention} 스크럼 작성 부탁드립니다."
                 print(f"\n{team_name} 팀에 멘션 발송 중...")
@@ -94,7 +90,7 @@ def main():
                 print(f"  - 멘션: {mention}")
 
                 slack_client.chat_postMessage(
-                    channel=SCRUM_CHANNEL_ID,
+                    channel=config.channel_id,
                     thread_ts=thread_ts,
                     text=reply_text,
                 )

--- a/scrum_config.yaml
+++ b/scrum_config.yaml
@@ -1,0 +1,56 @@
+channel_id: "C09277NGUET"
+
+notion_databases:
+  main:
+    data_source_id: "3e050c5a-11f3-4a3e-b6d0-498fe06c9d7b"
+    properties:
+      title: "제목"
+      status: "상태"
+      assignee: "담당자"
+      timeline: "타임라인"
+      pr: "GitHub 풀 리퀘스트"
+    in_progress_statuses: ["진행", "리뷰"]
+
+  explore:
+    data_source_id: "3141cc82-0da6-8103-913c-000ba234b439"
+    properties:
+      title: "작업"
+      status: "진행 상태"
+      assignee: "담당자"
+      timeline: "마감일"
+    in_progress_statuses: ["진행 중", "테스트 중"]
+
+squads:
+  - handle: "기획"
+    display_name: "기획"
+    slack_usergroup_id: "S092KHHE0AF"
+    notion_db: main
+    pr_warning: false
+
+  - handle: "fe"
+    display_name: "FE"
+    slack_usergroup_id: "S07V4G2QJJY"
+    notion_db: main
+    pr_warning: true
+
+  - handle: "be"
+    display_name: "BE"
+    slack_usergroup_id: "S085DBK2TFD"
+    notion_db: main
+    pr_warning: true
+
+  - handle: "ie"
+    display_name: "IE"
+    slack_usergroup_id: "S08628PEEUQ"
+    notion_db: main
+    pr_warning: true
+
+  - handle: "탐색"
+    display_name: "탐색"
+    slack_usergroup_id: "S0AJD6M5LH4"
+    notion_db: explore
+    pr_warning: false
+
+personal_scrums:
+  - name: "이창환"
+    slack_user_id: "U02HT4EU4VD"

--- a/service/scrum_config.py
+++ b/service/scrum_config.py
@@ -1,0 +1,135 @@
+"""
+스크럼 설정 로드
+
+scrum_config.yaml에서 스크럼 관련 설정을 로드합니다.
+"""
+
+import os
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+
+@dataclass(frozen=True)
+class NotionDBProperties:
+    """Notion DB 프로퍼티 이름 매핑"""
+
+    title: str
+    status: str
+    assignee: str
+    timeline: str
+    pr: str | None = None
+
+
+@dataclass(frozen=True)
+class NotionDBConfig:
+    """Notion DB 설정"""
+
+    name: str
+    data_source_id: str
+    properties: NotionDBProperties
+    in_progress_statuses: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ScrumSquad:
+    """스크럼 참여 스쿼드"""
+
+    handle: str
+    display_name: str
+    slack_usergroup_id: str
+    notion_db: NotionDBConfig
+    pr_warning: bool = True
+
+
+@dataclass(frozen=True)
+class PersonalScrum:
+    """개인 스크럼"""
+
+    name: str
+    slack_user_id: str
+
+
+@dataclass(frozen=True)
+class ScrumConfig:
+    """스크럼 전체 설정"""
+
+    channel_id: str
+    notion_databases: dict[str, NotionDBConfig]
+    squads: list[ScrumSquad]
+    personal_scrums: list[PersonalScrum]
+
+
+def _parse_config(raw: dict) -> ScrumConfig:
+    """YAML dict를 ScrumConfig로 변환"""
+    # Notion databases
+    notion_databases = {}
+    for name, db_raw in raw.get("notion_databases", {}).items():
+        props = db_raw["properties"]
+        notion_databases[name] = NotionDBConfig(
+            name=name,
+            data_source_id=db_raw["data_source_id"],
+            properties=NotionDBProperties(
+                title=props["title"],
+                status=props["status"],
+                assignee=props["assignee"],
+                timeline=props["timeline"],
+                pr=props.get("pr"),
+            ),
+            in_progress_statuses=db_raw.get("in_progress_statuses", []),
+        )
+
+    # Squads
+    squads = []
+    for squad_raw in raw.get("squads", []):
+        db_name = squad_raw["notion_db"]
+        if db_name not in notion_databases:
+            raise ValueError(
+                f"스쿼드 '{squad_raw['handle']}'가 참조하는 "
+                f"notion_db '{db_name}'가 notion_databases에 없습니다."
+            )
+        squads.append(
+            ScrumSquad(
+                handle=squad_raw["handle"],
+                display_name=squad_raw["display_name"],
+                slack_usergroup_id=squad_raw["slack_usergroup_id"],
+                notion_db=notion_databases[db_name],
+                pr_warning=squad_raw.get("pr_warning", True),
+            )
+        )
+
+    # Personal scrums
+    personal_scrums = [
+        PersonalScrum(name=p["name"], slack_user_id=p["slack_user_id"])
+        for p in raw.get("personal_scrums", [])
+    ]
+
+    return ScrumConfig(
+        channel_id=raw["channel_id"],
+        notion_databases=notion_databases,
+        squads=squads,
+        personal_scrums=personal_scrums,
+    )
+
+
+@lru_cache(maxsize=1)
+def load_scrum_config(config_path: str | None = None) -> ScrumConfig:
+    """
+    스크럼 설정 파일 로드
+
+    Args:
+        config_path: YAML 파일 경로. None이면 환경변수 또는 기본 경로 사용.
+
+    Returns:
+        ScrumConfig: 파싱된 설정
+    """
+    if config_path is None:
+        config_path = os.environ.get(
+            "SCRUM_CONFIG_PATH",
+            str(Path(__file__).parent.parent / "scrum_config.yaml"),
+        )
+    with open(config_path) as f:
+        raw = yaml.safe_load(f)
+    return _parse_config(raw)

--- a/tests/test_scrum_config.py
+++ b/tests/test_scrum_config.py
@@ -1,0 +1,111 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from service.scrum_config import (
+    NotionDBConfig,
+    PersonalScrum,
+    ScrumConfig,
+    ScrumSquad,
+    load_scrum_config,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """각 테스트 전후로 lru_cache 초기화"""
+    load_scrum_config.cache_clear()
+    yield
+    load_scrum_config.cache_clear()
+
+
+def test_load_actual_config():
+    """실제 scrum_config.yaml을 로드하여 기본 구조 검증"""
+    config_path = str(Path(__file__).parent.parent / "scrum_config.yaml")
+    config = load_scrum_config(config_path)
+
+    assert isinstance(config, ScrumConfig)
+    assert config.channel_id == "C09277NGUET"
+    assert len(config.notion_databases) == 2
+    assert "main" in config.notion_databases
+    assert "explore" in config.notion_databases
+    assert len(config.squads) == 5
+    assert len(config.personal_scrums) == 1
+
+
+def test_squad_order_preserved():
+    """squads 순서가 YAML 정의 순서대로 유지되는지 검증"""
+    config_path = str(Path(__file__).parent.parent / "scrum_config.yaml")
+    config = load_scrum_config(config_path)
+
+    handles = [s.handle for s in config.squads]
+    assert handles == ["기획", "fe", "be", "ie", "탐색"]
+
+
+def test_notion_db_reference():
+    """스쿼드가 올바른 NotionDBConfig를 참조하는지 검증"""
+    config_path = str(Path(__file__).parent.parent / "scrum_config.yaml")
+    config = load_scrum_config(config_path)
+
+    fe_squad = next(s for s in config.squads if s.handle == "fe")
+    explore_squad = next(s for s in config.squads if s.handle == "탐색")
+
+    assert fe_squad.notion_db.name == "main"
+    assert explore_squad.notion_db.name == "explore"
+    assert explore_squad.notion_db.properties.pr is None
+
+
+def test_pr_warning_config():
+    """PR 경고 설정이 올바르게 로드되는지 검증"""
+    config_path = str(Path(__file__).parent.parent / "scrum_config.yaml")
+    config = load_scrum_config(config_path)
+
+    squad_map = {s.handle: s for s in config.squads}
+    assert squad_map["기획"].pr_warning is False
+    assert squad_map["fe"].pr_warning is True
+    assert squad_map["탐색"].pr_warning is False
+
+
+def test_invalid_db_reference():
+    """존재하지 않는 notion_db 참조 시 ValueError"""
+    raw = {
+        "channel_id": "C000",
+        "notion_databases": {},
+        "squads": [
+            {
+                "handle": "test",
+                "display_name": "Test",
+                "slack_usergroup_id": "S000",
+                "notion_db": "nonexistent",
+            }
+        ],
+    }
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(raw, f)
+        f.flush()
+        with pytest.raises(ValueError, match="nonexistent"):
+            load_scrum_config(f.name)
+    os.unlink(f.name)
+
+
+def test_env_var_override():
+    """SCRUM_CONFIG_PATH 환경변수로 경로 오버라이드"""
+    config_path = str(Path(__file__).parent.parent / "scrum_config.yaml")
+    os.environ["SCRUM_CONFIG_PATH"] = config_path
+    try:
+        config = load_scrum_config()
+        assert isinstance(config, ScrumConfig)
+    finally:
+        del os.environ["SCRUM_CONFIG_PATH"]
+
+
+def test_personal_scrum():
+    """개인 스크럼 설정 검증"""
+    config_path = str(Path(__file__).parent.parent / "scrum_config.yaml")
+    config = load_scrum_config(config_path)
+
+    assert config.personal_scrums[0].name == "이창환"
+    assert config.personal_scrums[0].slack_user_id == "U02HT4EU4VD"


### PR DESCRIPTION
## 배경

스크럼 기능(post_scrum_message, schedule_scrum_mention)에 팀 정보, 채널 ID, Notion DB 설정이 4개 이상 파일에 하드코딩되어 있어 새 스쿼드 추가 시 최소 4개 파일 수정이 필요했습니다.

## 변경사항

- `scrum_config.yaml` 추가: 스크럼 전용 선언형 설정 파일 (스쿼드, Notion DB, 채널)
- `service/scrum_config.py` 추가: YAML 로더 + dataclass 정의 (`load_scrum_config()`)
- `scripts/post_scrum_message.py`: 하드코딩된 팀/DB/채널 상수 제거, config 루프로 전환
- `scripts/schedule_scrum_mention.py`: 하드코딩된 `TEAM_MENTIONS` dict 제거, config에서 동적 생성
- `tests/test_scrum_config.py` 추가: config 로딩, 순서 보존, DB 참조 검증, 에러 케이스 테스트
- `requirements.txt`: PyYAML 추가

## 대안 분석

- Python 모듈 기반 config: 선언형이 아닌 코드 수정이 필요. YAML이 더 선언적
- 전체 기능 (manage_tasks_daily, route_bug) 통합 config: 기능 간 독립성 우선. 스크럼 전용으로 분리

## 검증

- `pytest tests/test_scrum_config.py` 7개 테스트 통과
- 시맨틱 보존: 동일한 순서, 동일한 로직, 동일한 출력
- 새 스쿼드 추가 시 `scrum_config.yaml`만 편집하면 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)