### PR TITLE
feat: 스쿼드 체계 전환 및 스크럼 config 확장

### DIFF
--- a/scripts/post_scrum_message.py
+++ b/scripts/post_scrum_message.py
@@ -51,10 +51,13 @@ def main():
 
     if args.dry_run:
         print("=== DRY RUN MODE ===")
-        print(f"채널: {config.channel_id}\n")
 
-    # 1. 안내 메시지 발송
-    send_intro_message(slack_client, config.channel_id, args.dry_run)
+    # 스쿼드 채널 목록 (인트로 메시지에서 다른 채널 안내용)
+    squad_channel_ids = list(dict.fromkeys(s.slack_channel_id for s in config.squads))
+
+    # 1. 각 스쿼드 채널에 안내 메시지 발송
+    for channel_id in squad_channel_ids:
+        send_intro_message(slack_client, channel_id, squad_channel_ids, args.dry_run)
 
     # 2. 스쿼드별 스크럼
     for squad in config.squads:
@@ -63,34 +66,44 @@ def main():
             slack_client,
             email_to_user_id,
             squad,
-            config.channel_id,
             args.dry_run,
         )
 
     # 3. 개인 스크럼
     for personal in config.personal_scrums:
-        send_personal_scrum(slack_client, personal, config.channel_id, args.dry_run)
+        send_personal_scrum(slack_client, personal, args.dry_run)
 
     if args.dry_run:
         print("\n=== DRY RUN COMPLETED ===")
 
 
-def send_intro_message(slack_client: WebClient, channel_id: str, dry_run: bool = False):
+def send_intro_message(
+    slack_client: WebClient,
+    channel_id: str,
+    all_channel_ids: list[str],
+    dry_run: bool = False,
+):
     """
     안내 메시지 발송
 
     Args:
         slack_client: Slack WebClient
-        channel_id: 스크럼 채널 ID
+        channel_id: 발송 대상 채널 ID
+        all_channel_ids: 전체 스쿼드 채널 ID 목록 (다른 채널 안내용)
         dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
     """
     intro_text = "오늘 스크럼을 시작합니다. 4:40까지 작성 부탁드립니다!"
 
-    detail_text = """스크럼의 목적은 팀내의 진행상황을 확인하고, 장애를 파악하는 것입니다.
+    # 다른 스쿼드 채널 링크 생성
+    other_channels = " ".join(
+        f"<#{cid}>" for cid in all_channel_ids if cid != channel_id
+    )
+
+    detail_text = f"""스크럼의 목적은 팀내의 진행상황을 확인하고, 장애를 파악하는 것입니다.
 팀원이 스크럼 중 장애를 보고하면 각 마스터(김예원 엄은상 이창환)는
 장애를 최소화 하기 위해 스크럼 후 다른 팀의 협조로 연계해주시면 되겠습니다.
 다른 팀 스크럼이 궁금하시면 본인 팀의 스크럼이 끝나고 서면으로 남겨진 내용을 자유롭게 확인하시면 됩니다.
-#a_스크럼_제품 #a_스크럼_고객 #a_스크럼_콘텐츠
+{other_channels}
 다른 팀의 지원이 필요하시면 본인 팀 스크럼 때, 마스터를 통해 지원을 요청 주시면 됩니다.
 (사실 스크럼이 아니더라도 업무 중 자유롭게 요청 주셔도 됩니다.)
 ---------------------------------------------------------------------------
@@ -103,7 +116,7 @@ def send_intro_message(slack_client: WebClient, channel_id: str, dry_run: bool =
 - AAA 이슈로 B팀과 협업 요청"""
 
     if dry_run:
-        print(f"\n[안내 메시지]")
+        print(f"\n[안내 메시지] 채널: {channel_id}")
         print(intro_text)
         print(f"  └─ 스레드: {detail_text[:100]}...")
     else:
@@ -127,7 +140,6 @@ def send_team_scrum(
     slack_client: WebClient,
     email_to_user_id: dict[str, str],
     squad: ScrumSquad,
-    channel_id: str,
     dry_run: bool = False,
 ):
     """
@@ -138,14 +150,13 @@ def send_team_scrum(
         slack_client: Slack WebClient
         email_to_user_id: 이메일 -> Slack User ID 매핑
         squad: 스쿼드 설정
-        channel_id: 스크럼 채널 ID
         dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
     """
     # 메인 메시지
-    text = f"{squad.display_name}팀 스크럼"
+    text = f"{squad.display_name}"
 
     if dry_run:
-        print(f"\n[{squad.display_name}팀 스크럼]")
+        print(f"\n[{squad.display_name}] 채널: {squad.slack_channel_id}")
         print(text)
 
     # 팀 멤버의 진행 중인 태스크 조회
@@ -197,7 +208,7 @@ def send_team_scrum(
     else:
         # 실제 메시지 발송
         response = slack_client.chat_postMessage(
-            channel=channel_id,
+            channel=squad.slack_channel_id,
             text=text,
         )
         thread_ts = response["ts"]
@@ -205,7 +216,7 @@ def send_team_scrum(
         # 인원별 메시지를 스레드에 발송
         for msg in thread_messages:
             slack_client.chat_postMessage(
-                channel=channel_id,
+                channel=squad.slack_channel_id,
                 thread_ts=thread_ts,
                 text=msg,
             )
@@ -214,7 +225,6 @@ def send_team_scrum(
 def send_personal_scrum(
     slack_client: WebClient,
     personal: PersonalScrum,
-    channel_id: str,
     dry_run: bool = False,
 ):
     """
@@ -223,17 +233,16 @@ def send_personal_scrum(
     Args:
         slack_client: Slack WebClient
         personal: 개인 스크럼 설정
-        channel_id: 스크럼 채널 ID
         dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
     """
-    text = f"{personal.name} 스크럼"
+    text = personal.name
 
     if dry_run:
-        print(f"\n[{personal.name} 스크럼]")
+        print(f"\n[{personal.name}] 채널: {personal.slack_channel_id}")
         print(text)
     else:
         slack_client.chat_postMessage(
-            channel=channel_id,
+            channel=personal.slack_channel_id,
             text=text,
         )
 

--- a/scripts/schedule_scrum_mention.py
+++ b/scripts/schedule_scrum_mention.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import os
 import time
+from collections import defaultdict
 
 from dotenv import load_dotenv
 from slack_sdk import WebClient
@@ -26,12 +27,23 @@ def main():
     config = load_scrum_config()
     slack_client = WebClient(token=os.environ.get("SLACK_BOT_TOKEN"))
 
-    # config에서 팀별 멘션 구성
-    team_mentions = {}
+    # config에서 팀별 멘션 구성 (display_name -> mention, channel_id)
+    team_entries = {}
     for squad in config.squads:
-        team_mentions[squad.display_name] = f"<!subteam^{squad.slack_usergroup_id}>"
+        team_entries[squad.display_name] = {
+            "mention": f"<!subteam^{squad.slack_usergroup_id}>",
+            "channel_id": squad.slack_channel_id,
+        }
     for personal in config.personal_scrums:
-        team_mentions[personal.name] = f"<@{personal.slack_user_id}>"
+        team_entries[personal.name] = {
+            "mention": f"<@{personal.slack_user_id}>",
+            "channel_id": personal.slack_channel_id,
+        }
+
+    # 채널별로 검색할 팀 이름 그룹화
+    channel_to_team_names: dict[str, list[str]] = defaultdict(list)
+    for team_name, entry in team_entries.items():
+        channel_to_team_names[entry["channel_id"]].append(team_name)
 
     # 16:00에 보낸 스크럼 메시지 찾기 (최근 2시간 이내)
     now = time.time()
@@ -41,62 +53,50 @@ def main():
     print(
         f"검색 시작 시간: {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(oldest))}"
     )
-    print(f"채널 ID: {config.channel_id}")
+    print(f"검색 대상 채널: {list(channel_to_team_names.keys())}")
 
     try:
-        # 채널의 최근 메시지 조회
-        # Slack API는 oldest를 정수 형태의 문자열로 전달해야 함
-        print("\n메시지 조회 중...")
-        response = slack_client.conversations_history(
-            channel=config.channel_id,
-            oldest=str(int(oldest)),  # float를 int로 변환 후 문자열로
-            limit=50,
-        )
+        # 채널별로 메시지 검색 및 멘션 발송
+        for channel_id, team_names in channel_to_team_names.items():
+            print(f"\n=== 채널 {channel_id} 검색 ===")
+            print(f"매칭 대상: {team_names}")
 
-        messages = response.get("messages", [])
-        print(f"조회된 메시지 수: {len(messages)}")
+            response = slack_client.conversations_history(
+                channel=channel_id,
+                oldest=str(int(oldest)),
+                limit=50,
+            )
 
-        # 각 팀 스크럼 메시지 찾기
-        team_threads = {}
-        print("\n=== 메시지 분석 시작 ===")
-        for idx, message in enumerate(messages, 1):
-            text = message.get("text", "")
-            ts = message.get("ts", "")
-            msg_time = time.strftime("%H:%M:%S", time.localtime(float(ts)))
+            messages = response.get("messages", [])
+            print(f"조회된 메시지 수: {len(messages)}")
 
-            print(f"\n[메시지 {idx}] 시간: {msg_time}")
-            print(f"텍스트: {text[:100]}{'...' if len(text) > 100 else ''}")
+            # 팀 스크럼 메시지 찾기
+            team_threads = {}
+            for idx, message in enumerate(messages, 1):
+                text = message.get("text", "")
+                ts = message.get("ts", "")
+                msg_time = time.strftime("%H:%M:%S", time.localtime(float(ts)))
 
-            # 팀별 스크럼 메시지 매칭
-            for team_name in team_mentions:
-                if f"{team_name}팀 스크럼" in text or f"{team_name} 스크럼" in text:
-                    team_threads[team_name] = message["ts"]
-                    print(f"✓ {team_name} 팀 스레드 발견 (ts: {ts})")
-                    break
+                print(f"[메시지 {idx}] 시간: {msg_time}, 텍스트: {text[:80]}")
 
-        print(f"\n=== 팀 스레드 매칭 결과 ===")
-        print(f"발견된 팀 수: {len(team_threads)}")
-        for team_name, thread_ts in team_threads.items():
-            print(f"- {team_name}: {thread_ts}")
+                for team_name in team_names:
+                    if team_name in text:
+                        team_threads[team_name] = message["ts"]
+                        print(f"  -> {team_name} 스레드 발견 (ts: {ts})")
+                        break
 
-        # 각 팀 스레드에 멘션 답글 추가
-        print("\n=== 멘션 발송 시작 ===")
-        for team_name, thread_ts in team_threads.items():
-            mention = team_mentions.get(team_name)
-            if mention:
+            # 멘션 발송
+            for team_name, thread_ts in team_threads.items():
+                mention = team_entries[team_name]["mention"]
                 reply_text = f"{mention} 스크럼 작성 부탁드립니다."
-                print(f"\n{team_name} 팀에 멘션 발송 중...")
-                print(f"  - 스레드 ts: {thread_ts}")
-                print(f"  - 멘션: {mention}")
+                print(f"\n{team_name} 멘션 발송: {mention}")
 
                 slack_client.chat_postMessage(
-                    channel=config.channel_id,
+                    channel=channel_id,
                     thread_ts=thread_ts,
                     text=reply_text,
                 )
-                print(f"✓ {team_name} 팀 멘션 발송 완료")
-            else:
-                print(f"✗ {team_name} 팀의 멘션 정보 없음")
+                print(f"  -> 발송 완료")
 
         print("\n=== 스크럼 멘션 스케줄러 완료 ===")
 

--- a/scrum_config.yaml
+++ b/scrum_config.yaml
@@ -1,10 +1,27 @@
-channel_id: "C09277NGUET"
-
 notion_databases:
   main:
     data_source_id: "3e050c5a-11f3-4a3e-b6d0-498fe06c9d7b"
     properties:
       title: "제목"
+      status: "상태"
+      assignee: "담당자"
+      timeline: "타임라인"
+      pr: "GitHub 풀 리퀘스트"
+    in_progress_statuses: ["진행", "리뷰"]
+
+  hackathon:
+    data_source_id: "3281cc82-0da6-80fa-a459-000b0b93b641"
+    properties:
+      title: "이름"
+      status: "상태"
+      assignee: "담당자"
+      timeline: "마감일"
+    in_progress_statuses: ["진행 중"]
+
+  infra:
+    data_source_id: "3321cc82-0da6-80bf-b9b9-000b75cd1933"
+    properties:
+      title: "이름"
       status: "상태"
       assignee: "담당자"
       timeline: "타임라인"
@@ -21,36 +38,35 @@ notion_databases:
     in_progress_statuses: ["진행 중", "테스트 중"]
 
 squads:
-  - handle: "기획"
-    display_name: "기획"
-    slack_usergroup_id: "S092KHHE0AF"
+  - handle: "코들"
+    display_name: ":codle_bird: 코들 스쿼드"
+    slack_usergroup_id: "S0APF17S6TC"
+    slack_channel_id: "C09277NGUET"
     notion_db: main
+    pr_warning: true
+
+  - handle: "해커톤"
+    display_name: ":runner: 해커톤 스쿼드"
+    slack_usergroup_id: "S0APF182Q74"
+    slack_channel_id: "C09277NGUET"
+    notion_db: hackathon
     pr_warning: false
 
-  - handle: "fe"
-    display_name: "FE"
-    slack_usergroup_id: "S07V4G2QJJY"
-    notion_db: main
-    pr_warning: true
-
-  - handle: "be"
-    display_name: "BE"
-    slack_usergroup_id: "S085DBK2TFD"
-    notion_db: main
-    pr_warning: true
-
-  - handle: "ie"
-    display_name: "IE"
-    slack_usergroup_id: "S08628PEEUQ"
-    notion_db: main
-    pr_warning: true
-
   - handle: "탐색"
-    display_name: "탐색"
+    display_name: ":earth_asia: 탐색 스쿼드"
     slack_usergroup_id: "S0AJD6M5LH4"
+    slack_channel_id: "C09277NGUET"
     notion_db: explore
     pr_warning: false
 
+  - handle: "ie"
+    display_name: ":building_construction: 인프라 팀"
+    slack_usergroup_id: "S08628PEEUQ"
+    slack_channel_id: "C09277NGUET"
+    notion_db: infra
+    pr_warning: true
+
 personal_scrums:
-  - name: "이창환"
+  - name: "CTO"
     slack_user_id: "U02HT4EU4VD"
+    slack_channel_id: "C09277NGUET"

--- a/service/scrum_config.py
+++ b/service/scrum_config.py
@@ -40,6 +40,7 @@ class ScrumSquad:
     handle: str
     display_name: str
     slack_usergroup_id: str
+    slack_channel_id: str
     notion_db: NotionDBConfig
     pr_warning: bool = True
 
@@ -50,13 +51,13 @@ class PersonalScrum:
 
     name: str
     slack_user_id: str
+    slack_channel_id: str
 
 
 @dataclass(frozen=True)
 class ScrumConfig:
     """스크럼 전체 설정"""
 
-    channel_id: str
     notion_databases: dict[str, NotionDBConfig]
     squads: list[ScrumSquad]
     personal_scrums: list[PersonalScrum]
@@ -95,6 +96,7 @@ def _parse_config(raw: dict) -> ScrumConfig:
                 handle=squad_raw["handle"],
                 display_name=squad_raw["display_name"],
                 slack_usergroup_id=squad_raw["slack_usergroup_id"],
+                slack_channel_id=squad_raw["slack_channel_id"],
                 notion_db=notion_databases[db_name],
                 pr_warning=squad_raw.get("pr_warning", True),
             )
@@ -102,12 +104,15 @@ def _parse_config(raw: dict) -> ScrumConfig:
 
     # Personal scrums
     personal_scrums = [
-        PersonalScrum(name=p["name"], slack_user_id=p["slack_user_id"])
+        PersonalScrum(
+            name=p["name"],
+            slack_user_id=p["slack_user_id"],
+            slack_channel_id=p["slack_channel_id"],
+        )
         for p in raw.get("personal_scrums", [])
     ]
 
     return ScrumConfig(
-        channel_id=raw["channel_id"],
         notion_databases=notion_databases,
         squads=squads,
         personal_scrums=personal_scrums,

--- a/tests/test_scrum_config.py
+++ b/tests/test_scrum_config.py
@@ -28,7 +28,7 @@ def test_load_actual_config():
     config = load_scrum_config(config_path)
 
     assert isinstance(config, ScrumConfig)
-    assert len(config.notion_databases) == 3
+    assert len(config.notion_databases) == 4
     assert "main" in config.notion_databases
     assert "hackathon" in config.notion_databases
     assert "explore" in config.notion_databases
@@ -44,7 +44,12 @@ def test_squad_order_preserved():
     handles = [s.handle for s in config.squads]
     assert handles == ["코들", "해커톤", "탐색", "ie"]
     display_names = [s.display_name for s in config.squads]
-    assert display_names == ["코들 스쿼드", "해커톤 스쿼드", "탐색 스쿼드", "인프라팀"]
+    assert display_names == [
+        ":codle_bird: 코들 스쿼드",
+        ":runner: 해커톤 스쿼드",
+        ":earth_asia: 탐색 스쿼드",
+        ":building_construction: 인프라 팀",
+    ]
 
 
 def test_squad_channel_ids():
@@ -131,6 +136,6 @@ def test_personal_scrum():
     config_path = str(Path(__file__).parent.parent / "scrum_config.yaml")
     config = load_scrum_config(config_path)
 
-    assert config.personal_scrums[0].name == "이창환"
+    assert config.personal_scrums[0].name == "CTO"
     assert config.personal_scrums[0].slack_user_id == "U02HT4EU4VD"
     assert config.personal_scrums[0].slack_channel_id == "C09277NGUET"

--- a/tests/test_scrum_config.py
+++ b/tests/test_scrum_config.py
@@ -28,11 +28,11 @@ def test_load_actual_config():
     config = load_scrum_config(config_path)
 
     assert isinstance(config, ScrumConfig)
-    assert config.channel_id == "C09277NGUET"
-    assert len(config.notion_databases) == 2
+    assert len(config.notion_databases) == 3
     assert "main" in config.notion_databases
+    assert "hackathon" in config.notion_databases
     assert "explore" in config.notion_databases
-    assert len(config.squads) == 5
+    assert len(config.squads) == 4
     assert len(config.personal_scrums) == 1
 
 
@@ -42,7 +42,18 @@ def test_squad_order_preserved():
     config = load_scrum_config(config_path)
 
     handles = [s.handle for s in config.squads]
-    assert handles == ["기획", "fe", "be", "ie", "탐색"]
+    assert handles == ["코들", "해커톤", "탐색", "ie"]
+    display_names = [s.display_name for s in config.squads]
+    assert display_names == ["코들 스쿼드", "해커톤 스쿼드", "탐색 스쿼드", "인프라팀"]
+
+
+def test_squad_channel_ids():
+    """스쿼드별 채널 ID가 올바르게 로드되는지 검증"""
+    config_path = str(Path(__file__).parent.parent / "scrum_config.yaml")
+    config = load_scrum_config(config_path)
+
+    for squad in config.squads:
+        assert squad.slack_channel_id == "C09277NGUET"
 
 
 def test_notion_db_reference():
@@ -50,12 +61,24 @@ def test_notion_db_reference():
     config_path = str(Path(__file__).parent.parent / "scrum_config.yaml")
     config = load_scrum_config(config_path)
 
-    fe_squad = next(s for s in config.squads if s.handle == "fe")
-    explore_squad = next(s for s in config.squads if s.handle == "탐색")
+    squad_map = {s.handle: s for s in config.squads}
+    assert squad_map["코들"].notion_db.name == "main"
+    assert squad_map["해커톤"].notion_db.name == "hackathon"
+    assert squad_map["탐색"].notion_db.name == "explore"
+    assert squad_map["탐색"].notion_db.properties.pr is None
 
-    assert fe_squad.notion_db.name == "main"
-    assert explore_squad.notion_db.name == "explore"
-    assert explore_squad.notion_db.properties.pr is None
+
+def test_hackathon_db_properties():
+    """해커톤 DB의 프로퍼티가 올바르게 매핑되는지 검증"""
+    config_path = str(Path(__file__).parent.parent / "scrum_config.yaml")
+    config = load_scrum_config(config_path)
+
+    hackathon_db = config.notion_databases["hackathon"]
+    assert hackathon_db.properties.title == "이름"
+    assert hackathon_db.properties.status == "상태"
+    assert hackathon_db.properties.timeline == "마감일"
+    assert hackathon_db.properties.pr is None
+    assert hackathon_db.in_progress_statuses == ["진행 중"]
 
 
 def test_pr_warning_config():
@@ -64,21 +87,22 @@ def test_pr_warning_config():
     config = load_scrum_config(config_path)
 
     squad_map = {s.handle: s for s in config.squads}
-    assert squad_map["기획"].pr_warning is False
-    assert squad_map["fe"].pr_warning is True
+    assert squad_map["코들"].pr_warning is True
+    assert squad_map["해커톤"].pr_warning is False
     assert squad_map["탐색"].pr_warning is False
+    assert squad_map["ie"].pr_warning is True
 
 
 def test_invalid_db_reference():
     """존재하지 않는 notion_db 참조 시 ValueError"""
     raw = {
-        "channel_id": "C000",
         "notion_databases": {},
         "squads": [
             {
                 "handle": "test",
                 "display_name": "Test",
                 "slack_usergroup_id": "S000",
+                "slack_channel_id": "C000",
                 "notion_db": "nonexistent",
             }
         ],
@@ -109,3 +133,4 @@ def test_personal_scrum():
 
     assert config.personal_scrums[0].name == "이창환"
     assert config.personal_scrums[0].slack_user_id == "U02HT4EU4VD"
+    assert config.personal_scrums[0].slack_channel_id == "C09277NGUET"


### PR DESCRIPTION
## 배경

조직이 스쿼드 체계로 전환됨에 따라 스크럼 설정을 새 구조에 맞게 변경합니다.

## 변경사항

- 스쿼드 재구성: 기획/FE/BE/IE/탐색 → 코들/해커톤/탐색/인프라
- 스쿼드별 Slack 채널 지원 (`slack_channel_id` per squad, personal scrum 포함)
- Notion DB 추가: 인프라 팀 전용 DB (`infra`), 해커톤 스쿼드 DB (`hackathon`)
- 인트로 메시지를 모든 스쿼드 채널에 발송, 다른 채널 링크를 동적으로 생성
- `display_name`에 이모지 및 단위(스쿼드/팀) 포함, 메시지에서 "스크럼" 접미사 제거
- `schedule_scrum_mention`: 단일 채널 검색 → 채널별 그룹 검색으로 변경

## 검증

- `pytest tests/test_scrum_config.py` 9개 테스트 통과
- `--dry-run` 출력 확인
- Slack wet run으로 실제 발송 검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)