### PR TITLE
fix: hackathon/infra DB에 시작일/종료일 formula 반영

### DIFF
--- a/app/summarize_deployment.py
+++ b/app/summarize_deployment.py
@@ -108,23 +108,16 @@ def _query_deployment_tasks(
         {"property": props.status, "status": {"does_not_equal": "중단"}},
     ]
 
-    # "배포 예정 날짜"가 있는 DB (main)는 복합 조건, 없는 DB는 타임라인 end_date 사용
-    if props.end_date:
-        date_conditions = [
-            [{"property": "배포 예정 날짜", "date": {"equals": today_str}}],
-            [
-                {"property": "배포 예정 날짜", "date": {"is_empty": True}},
-                {"property": props.end_date, "date": {"equals": today_str}},
-            ],
+    # 종료일 == 오늘인 과업 조회
+    query_filter = {
+        "and": shared_filters
+        + [
+            {
+                "property": props.end_date,
+                "formula": {"date": {"equals": today_str}},
+            }
         ]
-        or_filters = [{"and": cond + shared_filters} for cond in date_conditions]
-        query_filter = {"or": or_filters}
-    else:
-        # end_date formula가 없는 DB: 타임라인 end == 오늘
-        query_filter = {
-            "and": shared_filters
-            + [{"property": props.timeline, "date": {"equals": today_str}}]
-        }
+    }
 
     result = notion.data_sources.query(
         **{"data_source_id": db_config.data_source_id, "filter": query_filter}

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,9 @@ notion_databases:
       title: "이름"
       status: "상태"
       assignee: "담당자"
-      timeline: "마감일"
+      timeline: "타임라인"
+      start_date: "시작일"
+      end_date: "종료일"
       pr: "GitHub 풀 리퀘스트"
     pending_statuses: ["대기"]
     in_progress_statuses: ["진행", "리뷰"]
@@ -30,6 +32,8 @@ notion_databases:
       status: "상태"
       assignee: "담당자"
       timeline: "타임라인"
+      start_date: "시작일"
+      end_date: "종료일"
       pr: "GitHub 풀 리퀘스트"
     pending_statuses: ["대기"]
     in_progress_statuses: ["진행", "리뷰"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,8 +62,9 @@ def test_notion_db_properties():
 
     hackathon = config.notion_databases["hackathon"]
     assert hackathon.properties.title == "이름"
-    assert hackathon.properties.start_date is None
-    assert hackathon.properties.end_date is None
+    assert hackathon.properties.timeline == "타임라인"
+    assert hackathon.properties.start_date == "시작일"
+    assert hackathon.properties.end_date == "종료일"
     assert hackathon.properties.pr == "GitHub 풀 리퀘스트"
     assert hackathon.pending_statuses == ["대기"]
     assert hackathon.in_progress_statuses == ["진행", "리뷰"]


### PR DESCRIPTION
## 변경사항

- hackathon: timeline 마감일→타임라인, start_date/end_date 추가
- infra: start_date/end_date 추가
- summarize_deployment: end_date formula 통일, fallback 로직 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)