### PR TITLE
refactor: manage_tasks_daily config 기반으로 전환

### DIFF
--- a/app/summarize_deployment.py
+++ b/app/summarize_deployment.py
@@ -147,8 +147,8 @@ def summarize_deployment(
     )
     tasks = []
     db_by_task_url: dict[str, NotionDBConfig] = {}
-    for squad in product_pipeline.squads:
-        db = squad.notion_db
+    for ps in product_pipeline.pipeline_squads:
+        db = ps.squad.notion_db
         if not db.properties.pr:
             continue
         squad_tasks = _query_deployment_tasks(notion, db, today_str)

--- a/config.yaml
+++ b/config.yaml
@@ -64,18 +64,22 @@ squads:
   - handle: "코들"
     slack_usergroup_id: "S0APF17S6TC"
     notion_db: main
+    pm_slack_user_id: "U075PUFNGHX"  # 예진
 
   - handle: "해커톤"
     slack_usergroup_id: "S0APF182Q74"
     notion_db: hackathon
+    pm_slack_user_id: "U02HT4EU4VD"  # 이창환
 
   - handle: "탐색"
     slack_usergroup_id: "S0AJD6M5LH4"
     notion_db: explore
+    pm_slack_user_id: "U02JLCWGETT"  # 배영빈
 
   - handle: "ie"
     slack_usergroup_id: "S08628PEEUQ"
     notion_db: infra
+    pm_slack_user_id: "U02HT4EU4VD"  # 이창환
 
   - handle: "콘텐츠"
     slack_usergroup_id: "S08LHAA2HL3"

--- a/config.yaml
+++ b/config.yaml
@@ -124,14 +124,12 @@ task_alerts:
             - alert_pending_but_started_tasks
             - alert_no_due_tasks
             - alert_no_tasks
-            - alert_schedule_feasibility
         - handle: "해커톤"
           alerts:
             - alert_overdue_tasks
             - alert_pending_but_started_tasks
             - alert_no_due_tasks
             - alert_no_tasks
-            - alert_schedule_feasibility
         - handle: "ie"
           alerts:
             - alert_overdue_tasks
@@ -139,7 +137,6 @@ task_alerts:
             - alert_no_due_tasks
             - alert_no_tasks
             - alert_no_upcoming_tasks
-            - alert_schedule_feasibility
 
     - name: "콘텐츠 본부"
       channel_id: "C091ZUBTCKU"

--- a/config.yaml
+++ b/config.yaml
@@ -124,6 +124,7 @@ task_alerts:
             - alert_pending_but_started_tasks
             - alert_no_due_tasks
             - alert_no_tasks
+            - alert_no_upcoming_tasks
         - handle: "해커톤"
           alerts:
             - alert_overdue_tasks
@@ -136,7 +137,6 @@ task_alerts:
             - alert_pending_but_started_tasks
             - alert_no_due_tasks
             - alert_no_tasks
-            - alert_no_upcoming_tasks
 
     - name: "콘텐츠 본부"
       channel_id: "C091ZUBTCKU"

--- a/config.yaml
+++ b/config.yaml
@@ -116,23 +116,39 @@ task_alerts:
   pipelines:
     - name: "제품 본부"
       channel_id: "C087PDC9VG8"
-      squads: ["코들", "해커톤", "ie"]
-      alerts:
-        - alert_overdue_tasks
-        - alert_pending_but_started_tasks
-        - alert_no_due_tasks
-        - alert_no_tasks
-        - alert_no_upcoming_tasks
-        - alert_schedule_feasibility
+      squads:
+        - handle: "코들"
+          alerts:
+            - alert_overdue_tasks
+            - alert_pending_but_started_tasks
+            - alert_no_due_tasks
+            - alert_no_tasks
+            - alert_schedule_feasibility
+        - handle: "해커톤"
+          alerts:
+            - alert_overdue_tasks
+            - alert_pending_but_started_tasks
+            - alert_no_due_tasks
+            - alert_no_tasks
+            - alert_schedule_feasibility
+        - handle: "ie"
+          alerts:
+            - alert_overdue_tasks
+            - alert_pending_but_started_tasks
+            - alert_no_due_tasks
+            - alert_no_tasks
+            - alert_no_upcoming_tasks
+            - alert_schedule_feasibility
 
     - name: "콘텐츠 본부"
       channel_id: "C091ZUBTCKU"
-      squads: ["콘텐츠"]
-      alerts:
-        - alert_overdue_tasks
-        - alert_pending_but_started_tasks
-        - alert_no_due_tasks
-        - alert_no_tasks
+      squads:
+        - handle: "콘텐츠"
+          alerts:
+            - alert_overdue_tasks
+            - alert_pending_but_started_tasks
+            - alert_no_due_tasks
+            - alert_no_tasks
 
 scheduled_jobs:
   - name: validate_customer_reports

--- a/config.yaml
+++ b/config.yaml
@@ -83,7 +83,7 @@ squads:
     display_name: ":building_construction: 인프라 팀"
     slack_usergroup_id: "S08628PEEUQ"
     notion_db: infra
-    pm_slack_user_id: "U02HT4EU4VD"  # 이창환
+    pm_slack_user_id: "U02PFUPCJNM"  # 류호선
 
   - handle: "콘텐츠"
     display_name: ":pencil2: 콘텐츠 본부"

--- a/config.yaml
+++ b/config.yaml
@@ -62,48 +62,49 @@ notion_databases:
 
 squads:
   - handle: "코들"
+    display_name: ":codle_bird: 코들 스쿼드"
     slack_usergroup_id: "S0APF17S6TC"
     notion_db: main
     pm_slack_user_id: "U075PUFNGHX"  # 예진
 
   - handle: "해커톤"
+    display_name: ":runner: 해커톤 스쿼드"
     slack_usergroup_id: "S0APF182Q74"
     notion_db: hackathon
     pm_slack_user_id: "U02HT4EU4VD"  # 이창환
 
   - handle: "탐색"
+    display_name: ":earth_asia: 탐색 스쿼드"
     slack_usergroup_id: "S0AJD6M5LH4"
     notion_db: explore
     pm_slack_user_id: "U02JLCWGETT"  # 배영빈
 
   - handle: "ie"
+    display_name: ":building_construction: 인프라 팀"
     slack_usergroup_id: "S08628PEEUQ"
     notion_db: infra
     pm_slack_user_id: "U02HT4EU4VD"  # 이창환
 
   - handle: "콘텐츠"
+    display_name: ":pencil2: 콘텐츠 본부"
     slack_usergroup_id: "S08LHAA2HL3"
     notion_db: contents
 
 scrum:
   squads:
     - handle: "코들"
-      display_name: ":codle_bird: 코들 스쿼드"
       channel_id: "C09277NGUET"
       pr_warning: true
 
     - handle: "해커톤"
-      display_name: ":runner: 해커톤 스쿼드"
       channel_id: "C09277NGUET"
       pr_warning: true
 
     - handle: "탐색"
-      display_name: ":earth_asia: 탐색 스쿼드"
       channel_id: "C09277NGUET"
       pr_warning: false
 
     - handle: "ie"
-      display_name: ":building_construction: 인프라 팀"
       channel_id: "C09277NGUET"
       pr_warning: true
 

--- a/scripts/manage_tasks_daily.py
+++ b/scripts/manage_tasks_daily.py
@@ -43,14 +43,14 @@ def main():
     for pipeline in config.task_alerts.pipelines:
         send_intro_message(slack_client, pipeline.channel_id)
 
-        for squad in pipeline.squads:
-            db = squad.notion_db
-            for alert_name in pipeline.alerts:
+        for ps in pipeline.pipeline_squads:
+            squad = ps.squad
+            for alert_name in ps.alerts:
                 alert_fn = ALERT_FUNCTIONS[alert_name]
                 alert_fn(
                     notion=notion,
                     slack_client=slack_client,
-                    db_config=db,
+                    db_config=squad.notion_db,
                     channel_id=pipeline.channel_id,
                     email_to_user_id=email_to_user_id,
                     group_handle=squad.handle,
@@ -968,15 +968,15 @@ def run_schedule_feasibility_only(dry_run: bool = False):
     email_to_user_id = get_email_to_user_id(slack_client)
 
     for pipeline in config.task_alerts.pipelines:
-        for squad in pipeline.squads:
-            if "alert_schedule_feasibility" in pipeline.alerts:
+        for ps in pipeline.pipeline_squads:
+            if "alert_schedule_feasibility" in ps.alerts:
                 alert_schedule_feasibility(
                     notion=notion,
                     slack_client=slack_client,
-                    db_config=squad.notion_db,
+                    db_config=ps.squad.notion_db,
                     channel_id=pipeline.channel_id,
                     email_to_user_id=email_to_user_id,
-                    group_handle=squad.handle,
+                    group_handle=ps.squad.handle,
                     dry_run=dry_run,
                 )
 

--- a/scripts/manage_tasks_daily.py
+++ b/scripts/manage_tasks_daily.py
@@ -25,6 +25,9 @@ load_dotenv()
 
 ALERT_FUNCTIONS: dict[str, callable] = {}
 
+# alert_schedule_feasibility는 스레드 메시지를 직접 보내므로 별도 관리
+DIRECT_SEND_ALERTS = {"alert_schedule_feasibility"}
+
 
 def _register(fn):
     ALERT_FUNCTIONS[fn.__name__] = fn
@@ -41,11 +44,40 @@ def main():
     email_to_user_id = get_email_to_user_id(slack_client)
 
     for pipeline in config.task_alerts.pipelines:
-        send_intro_message(slack_client, pipeline.channel_id)
-
         for ps in pipeline.pipeline_squads:
             squad = ps.squad
+
+            # 그룹핑 대상 alert 수집
+            items: list[tuple[str | None, str]] = []
             for alert_name in ps.alerts:
+                if alert_name in DIRECT_SEND_ALERTS:
+                    continue
+                alert_fn = ALERT_FUNCTIONS[alert_name]
+                result = alert_fn(
+                    notion=notion,
+                    slack_client=slack_client,
+                    db_config=squad.notion_db,
+                    channel_id=pipeline.channel_id,
+                    email_to_user_id=email_to_user_id,
+                    group_handle=squad.handle,
+                    pm_slack_user_id=squad.pm_slack_user_id,
+                )
+                if result:
+                    items.extend(result)
+
+            # 담당자별 그룹핑 후 메시지 전송
+            if items:
+                _send_squad_summary(
+                    slack_client,
+                    pipeline.channel_id,
+                    squad,
+                    items,
+                )
+
+            # 별도 전송 alert 실행 (alert_schedule_feasibility 등)
+            for alert_name in ps.alerts:
+                if alert_name not in DIRECT_SEND_ALERTS:
+                    continue
                 alert_fn = ALERT_FUNCTIONS[alert_name]
                 alert_fn(
                     notion=notion,
@@ -58,40 +90,77 @@ def main():
                 )
 
 
-def send_intro_message(
+def _send_squad_summary(
     slack_client: WebClient,
     channel_id: str,
+    squad,
+    items: list[tuple[str | None, str]],
 ):
-    """
-    지연된 작업에 대한 인트로 메시지를 전송하는 함수
+    """스쿼드별 alert을 담당자별로 그룹핑하여 하나의 메시지로 전송"""
+    # 담당자별 그룹핑 (None → PM)
+    by_person: dict[str, list[str]] = defaultdict(list)
+    for slack_user_id, text in items:
+        if slack_user_id:
+            by_person[slack_user_id].append(text)
+        elif squad.pm_slack_user_id:
+            by_person[squad.pm_slack_user_id].append(text)
 
-    Args:
-        slack_client (WebClient): Slack
-        channel_id (str): Slack channel id
+    if not by_person:
+        return
 
-    Returns:
-        None
-    """
-    intro_message = (
-        "좋은 아침입니다! \n"
-        "아래 지연된 작업에 대해 적절한 사유를 댓글로 남기고, 로봇을 통해 일정을 변경해주시길 부탁드립니다.\n"
-        "항상 협조해 주셔서 감사합니다."
-    )
-    slack_client.chat_postMessage(channel=channel_id, text=intro_message)
+    sections = [f"{squad.display_name} 일일 작업 검토"]
+
+    for user_id, texts in by_person.items():
+        lines = [f"\n<@{user_id}> 님 아래 작업을 확인해주세요."]
+        for text in texts:
+            lines.append(f"• {text}")
+        sections.append("\n".join(lines))
+
+    message = "\n————————————————\n".join(sections)
+    slack_client.chat_postMessage(channel=channel_id, text=message)
+
+
+def _get_usergroup_members(
+    slack_client: WebClient, group_handle: str
+) -> list[str] | None:
+    """Slack usergroup의 멤버 ID 목록 반환"""
+    usergroups_response = slack_client.usergroups_list()
+    for group in usergroups_response["usergroups"]:
+        if group["handle"] == group_handle:
+            response = slack_client.usergroups_users_list(usergroup=group["id"])
+            return response.get("users", [])
+    print(f"[alert] 그룹 @{group_handle}를 찾을 수 없습니다.")
+    return None
+
+
+def _extract_task_assignee(
+    result: dict, props, email_to_user_id: dict
+) -> tuple[str, str, str | None]:
+    """노션 결과에서 작업명, URL, 담당자 Slack ID를 추출"""
+    try:
+        task_name = result["properties"][props.title]["title"][0]["text"]["content"]
+    except (KeyError, IndexError):
+        task_name = "제목 없음"
+    page_url = result["url"]
+    people = result["properties"][props.assignee]["people"]
+    slack_user_id = None
+    if people:
+        person = people[0].get("person")
+        if person:
+            slack_user_id = email_to_user_id.get(person["email"])
+    return task_name, page_url, slack_user_id
 
 
 @_register
 def alert_overdue_tasks(
     notion: NotionClient,
-    slack_client: WebClient,
     db_config: NotionDBConfig,
-    channel_id: str,
     email_to_user_id: dict,
     **kwargs,
-):
-    """대기 및 진행 중인 작업 중 종료일이 지난 작업을 슬랙으로 알림"""
+) -> list[tuple[str | None, str]]:
+    """대기 및 진행 중인 작업 중 종료일이 지난 작업"""
     if not db_config.properties.end_date:
-        return
+        return []
 
     today = datetime.now().date()
     props = db_config.properties
@@ -115,42 +184,28 @@ def alert_overdue_tasks(
         }
     )
 
+    items = []
     for result in results.get("results", []):
-        try:
-            task_name = result["properties"][props.title]["title"][0]["text"]["content"]
-        except (KeyError, IndexError):
-            task_name = "제목 없음"
-        page_url = result["url"]
-        people = result["properties"][props.assignee]["people"]
-        if people:
-            person = people[0].get("person")
-            if person:
-                assignee_email = person["email"]
-                slack_user_id = email_to_user_id.get(assignee_email)
-            else:
-                slack_user_id = None
-        else:
-            slack_user_id = None
-
-        if slack_user_id:
-            text = f"작업 <{page_url}|{task_name}>이(가) 기한이 지났습니다. <@{slack_user_id}> 확인 부탁드립니다."
-        else:
-            text = f"작업 <{page_url}|{task_name}>이(가) 기한이 지났으나 담당자를 확인할 수 없습니다."
-        slack_client.chat_postMessage(channel=channel_id, text=text)
+        task_name, page_url, slack_user_id = _extract_task_assignee(
+            result, props, email_to_user_id
+        )
+        text = f"작업 <{page_url}|{task_name}>이(가) 기한이 지났습니다."
+        if not slack_user_id:
+            text += " (담당자 확인 불가)"
+        items.append((slack_user_id, text))
+    return items
 
 
 @_register
 def alert_pending_but_started_tasks(
     notion: NotionClient,
-    slack_client: WebClient,
     db_config: NotionDBConfig,
-    channel_id: str,
     email_to_user_id: dict,
     **kwargs,
-):
-    """시작일이 지났으나 아직 대기 상태인 작업을 슬랙으로 알림"""
+) -> list[tuple[str | None, str]]:
+    """시작일이 지났으나 아직 대기 상태인 작업"""
     if not db_config.properties.start_date or not db_config.pending_statuses:
-        return
+        return []
 
     today = datetime.now().date()
     props = db_config.properties
@@ -178,40 +233,26 @@ def alert_pending_but_started_tasks(
         }
     )
 
+    items = []
     for result in results.get("results", []):
-        try:
-            task_name = result["properties"][props.title]["title"][0]["text"]["content"]
-        except (KeyError, IndexError):
-            task_name = "제목 없음"
-        page_url = result["url"]
-        people = result["properties"][props.assignee]["people"]
-        if people:
-            person = people[0].get("person")
-            if person:
-                assignee_email = person["email"]
-                slack_user_id = email_to_user_id.get(assignee_email)
-            else:
-                slack_user_id = None
-        else:
-            slack_user_id = None
-
-        if slack_user_id:
-            text = f"작업 <{page_url}|{task_name}>이(가) 시작일이 지났으나 아직 대기 상태입니다. <@{slack_user_id}> 확인 부탁드립니다."
-        else:
-            text = f"작업 <{page_url}|{task_name}>이(가) 시작일이 지났으나 아직 대기 상태이며, 담당자를 확인할 수 없습니다."
-        slack_client.chat_postMessage(channel=channel_id, text=text)
+        task_name, page_url, slack_user_id = _extract_task_assignee(
+            result, props, email_to_user_id
+        )
+        text = f"작업 <{page_url}|{task_name}>이(가) 시작일이 지났으나 아직 대기 상태입니다."
+        if not slack_user_id:
+            text += " (담당자 확인 불가)"
+        items.append((slack_user_id, text))
+    return items
 
 
 @_register
 def alert_no_due_tasks(
     notion: NotionClient,
-    slack_client: WebClient,
     db_config: NotionDBConfig,
-    channel_id: str,
     email_to_user_id: dict,
     **kwargs,
-):
-    """기간 산정 없이 진행 중인 작업을 슬랙으로 알림"""
+) -> list[tuple[str | None, str]]:
+    """기간 산정 없이 진행 중인 작업"""
     props = db_config.properties
 
     in_progress_filters = [
@@ -230,31 +271,16 @@ def alert_no_due_tasks(
         }
     )
 
+    items = []
     for result in results.get("results", []):
-        try:
-            task_name = result["properties"][props.title]["title"][0]["text"]["content"]
-        except (KeyError, IndexError):
-            task_name = "제목 없음"
-        page_url = result["url"]
-        people = result["properties"][props.assignee]["people"]
-        if people:
-            person = people[0].get("person")
-            if person:
-                assignee_email = person["email"]
-                slack_user_id = email_to_user_id.get(assignee_email)
-            else:
-                slack_user_id = None
-        else:
-            slack_user_id = None
-
-        if slack_user_id:
-            text = (
-                f"작업 <{page_url}|{task_name}>이(가) 기한이 지정되지 않은채로 진행되고 있습니다."
-                f"<@{slack_user_id}> 확인 부탁드립니다."
-            )
-        else:
-            text = f"작업 <{page_url}|{task_name}>이(가) 기한이 지정되지 않은채로 진행되고 있으나 담당자를 확인할 수 없습니다."
-        slack_client.chat_postMessage(channel=channel_id, text=text)
+        task_name, page_url, slack_user_id = _extract_task_assignee(
+            result, props, email_to_user_id
+        )
+        text = f"작업 <{page_url}|{task_name}>이(가) 기한이 지정되지 않은채로 진행되고 있습니다."
+        if not slack_user_id:
+            text += " (담당자 확인 불가)"
+        items.append((slack_user_id, text))
+    return items
 
 
 @_register
@@ -262,12 +288,11 @@ def alert_no_tasks(
     notion: NotionClient,
     slack_client: WebClient,
     db_config: NotionDBConfig,
-    channel_id: str,
     email_to_user_id: dict,
     group_handle: str,
     **kwargs,
-):
-    """아무 작업도 진행 중이지 않은 작업자를 슬랙으로 알림"""
+) -> list[tuple[str | None, str]]:
+    """아무 작업도 진행 중이지 않은 작업자"""
     props = db_config.properties
 
     in_progress_filters = [
@@ -291,56 +316,26 @@ def alert_no_tasks(
                 if email:
                     assigned_emails.add(email)
 
-    # 2. Slack 사용자 그룹 목록 중에서 지정된 handle인 그룹을 찾습니다.
-    usergroup_id = None
-    usergroups_response = slack_client.usergroups_list()
-    for group in usergroups_response["usergroups"]:
-        # 지정된 handle인 사용자 그룹 찾아 ID 획득
-        if group["handle"] == group_handle:
-            usergroup_id = group["id"]
-            break
+    group_user_ids = _get_usergroup_members(slack_client, group_handle)
+    if group_user_ids is None:
+        return []
 
-    # 3. 찾은 사용자 그룹의 멤버들을 조회하여, 각 Slack user ID를 얻습니다.
-    if usergroup_id is None:
-        slack_client.chat_postMessage(
-            channel=channel_id,
-            text=f"그룹 @{group_handle}를 찾을 수 없습니다. 확인부탁드립니다.",
-        )
-        return
-
-    group_users_response = slack_client.usergroups_users_list(usergroup=usergroup_id)
-    group_user_ids = group_users_response.get("users", [])
-
-    # 4. email_to_user_id는 "email -> slack user id" 매핑이므로,
-    #    그 반대("slack user id -> email") 매핑을 쉽게 얻기 위해 역으로 변환합니다.
     user_id_to_email = {v: k for k, v in email_to_user_id.items()}
+    team_emails = [
+        user_id_to_email[uid]
+        for uid in group_user_ids
+        if uid in user_id_to_email
+    ]
 
-    # 5. 그룹에 실제 등록된 멤버의 이메일 목록
-    team_emails = []
-    for user_id in group_user_ids:
-        email = user_id_to_email.get(user_id)
-        if email:
-            team_emails.append(email)
-
-    # 6. "아무 작업도 진행 중이지 않은" ⇒ 팀 멤버 중 assigned_emails에 없는 이메일
     unassigned_emails = set(team_emails) - assigned_emails
 
-    # 7. unassigned_emails에 속한 멤버들에게 알림 보내기
+    items = []
     for email in unassigned_emails:
         slack_user_id = email_to_user_id.get(email)
-        if slack_user_id:
-            text = (
-                f"<@{slack_user_id}> 현재 진행중인 작업이 없습니다. "
-                "혹시 진행해야 할 업무가 누락되지 않았는지 확인 부탁드립니다."
-            )
-        else:
-            # 혹시라도 email_to_user_id에 매핑되어 있지 않은 경우 처리
-            text = (
-                f"{email}님께서 현재 진행중인 작업이 없습니다. "
-                "혹시 진행해야 할 업무가 누락되지 않았는지 확인 부탁드립니다. "
-                "또한 이메일 매핑이 누락된 원인을 파악해주시길 바랍니다."
-            )
-        slack_client.chat_postMessage(channel=channel_id, text=text)
+        items.append(
+            (slack_user_id, "현재 진행중인 작업이 없습니다. 혹시 진행해야 할 업무가 누락되지 않았는지 확인 부탁드립니다.")
+        )
+    return items
 
 
 @_register
@@ -348,21 +343,19 @@ def alert_no_upcoming_tasks(
     notion: NotionClient,
     slack_client: WebClient,
     db_config: NotionDBConfig,
-    channel_id: str,
     email_to_user_id: dict,
     group_handle: str,
     pm_slack_user_id: str | None = None,
     **kwargs,
-):
+) -> list[tuple[str | None, str]]:
     """5일 후에 예정된 작업이 없는 작업자를 PM에게 알림"""
     props = db_config.properties
     if not props.start_date or not props.end_date:
-        return
+        return []
 
     if not pm_slack_user_id:
-        return
+        return []
 
-    # 영업일 기준 5일 후 날짜 계산
     target_date = get_nth_business_day_from(datetime.now().date(), 5)
 
     all_active = db_config.pending_statuses + db_config.in_progress_statuses
@@ -398,33 +391,16 @@ def alert_no_upcoming_tasks(
                 if email:
                     assigned_emails.add(email)
 
-    # Slack 사용자 그룹에서 지정된 handle인 그룹을 찾습니다.
-    usergroup_id = None
-    usergroups_response = slack_client.usergroups_list()
-    for group in usergroups_response["usergroups"]:
-        if group["handle"] == group_handle:
-            usergroup_id = group["id"]
-            break
+    group_user_ids = _get_usergroup_members(slack_client, group_handle)
+    if group_user_ids is None:
+        return []
 
-    if usergroup_id is None:
-        slack_client.chat_postMessage(
-            channel=channel_id,
-            text=f"그룹 @{group_handle}를 찾을 수 없습니다. 확인부탁드립니다.",
-        )
-        return
-
-    group_users_response = slack_client.usergroups_users_list(usergroup=usergroup_id)
-    group_user_ids = set(group_users_response.get("users", []))
-
-    # "slack user id -> email" 매핑 생성
     user_id_to_email = {v: k for k, v in email_to_user_id.items()}
-
-    # 그룹에 등록된 멤버의 이메일 목록
-    team_emails = []
-    for user_id in group_user_ids:
-        email = user_id_to_email.get(user_id)
-        if email:
-            team_emails.append(email)
+    team_emails = [
+        user_id_to_email[uid]
+        for uid in group_user_ids
+        if uid in user_id_to_email
+    ]
 
     # 5일 후 당일 종일 연차인 멤버 제외
     target_date_str = target_date.isoformat()
@@ -439,27 +415,27 @@ def alert_no_upcoming_tasks(
         email for email, days in vacation_days_by_email.items() if days >= 1.0
     }
 
-    # 5일 후에 예정된 작업이 없는 멤버 찾기 (연차자 제외)
     unassigned_emails = set(team_emails) - assigned_emails - on_leave_emails
 
-    # 예진님에게 알림 보내기
-    if unassigned_emails:
-        member_mentions = []
-        for email in unassigned_emails:
-            slack_user_id = email_to_user_id.get(email)
-            if slack_user_id:
-                member_mentions.append(f"<@{slack_user_id}>")
-            else:
-                member_mentions.append(email)
+    if not unassigned_emails:
+        return []
 
-        members_text = ", ".join(member_mentions)
-        weekday_names = ["월", "화", "수", "목", "금", "토", "일"]
-        target_weekday = weekday_names[target_date.weekday()]
-        text = (
-            f"<@{pm_slack_user_id}> 5일 후 {target_date.month}/{target_date.day}({target_weekday})에 예정된 작업이 없는 멤버가 있습니다: {members_text}\n"
-            "로드맵 점검 부탁드립니다."
-        )
-        slack_client.chat_postMessage(channel=channel_id, text=text)
+    member_mentions = []
+    for email in unassigned_emails:
+        slack_user_id = email_to_user_id.get(email)
+        if slack_user_id:
+            member_mentions.append(f"<@{slack_user_id}>")
+        else:
+            member_mentions.append(email)
+
+    members_text = ", ".join(member_mentions)
+    weekday_names = ["월", "화", "수", "목", "금", "토", "일"]
+    target_weekday = weekday_names[target_date.weekday()]
+    text = (
+        f"5일 후 {target_date.month}/{target_date.day}({target_weekday})에 "
+        f"예정된 작업이 없는 멤버가 있습니다: {members_text}\n로드맵 점검 부탁드립니다."
+    )
+    return [(pm_slack_user_id, text)]
 
 
 def alert_no_후속_작업(

--- a/scripts/manage_tasks_daily.py
+++ b/scripts/manage_tasks_daily.py
@@ -29,19 +29,37 @@ ALERT_FUNCTIONS: dict[str, callable] = {}
 DIRECT_SEND_ALERTS = {"alert_schedule_feasibility"}
 
 
+class DryRunSlackClient:
+    """dry-run 모드에서 Slack 메시지를 콘솔에 출력하는 래퍼"""
+
+    def __init__(self, real_client: WebClient):
+        self._client = real_client
+        self._ts_counter = 0
+
+    def chat_postMessage(self, *, channel, text, thread_ts=None, **kwargs):
+        prefix = f"  [thread {thread_ts}]" if thread_ts else ""
+        print(f"[dry-run]{prefix} {text}")
+        self._ts_counter += 1
+        return {"ts": f"dry.{self._ts_counter}"}
+
+    def __getattr__(self, name):
+        return getattr(self._client, name)
+
+
 def _register(fn):
     ALERT_FUNCTIONS[fn.__name__] = fn
     return fn
 
 
-def main():
+def main(dry_run: bool = False):
     config = load_config()
     notion = NotionClient(
         auth=os.environ.get("NOTION_TOKEN"), notion_version="2025-09-03"
     )
-    slack_client = WebClient(token=os.environ.get("SLACK_BOT_TOKEN"))
+    real_client = WebClient(token=os.environ.get("SLACK_BOT_TOKEN"))
+    slack_client = DryRunSlackClient(real_client) if dry_run else real_client
 
-    email_to_user_id = get_email_to_user_id(slack_client)
+    email_to_user_id = get_email_to_user_id(real_client)
 
     for pipeline in config.task_alerts.pipelines:
         for ps in pipeline.pipeline_squads:
@@ -91,7 +109,7 @@ def main():
 
 
 def _send_squad_summary(
-    slack_client: WebClient,
+    slack_client,
     channel_id: str,
     squad,
     items: list[tuple[str | None, str]],
@@ -108,16 +126,24 @@ def _send_squad_summary(
     if not by_person:
         return
 
-    sections = [f"{squad.display_name} 일일 작업 검토"]
+    # 스쿼드 헤더 메시지
+    slack_client.chat_postMessage(
+        channel=channel_id,
+        text=f"{squad.display_name} 일일 작업 검토",
+    )
 
+    # 담당자별 메시지 + 스레드 댓글
     for user_id, texts in by_person.items():
-        lines = [f"\n<@{user_id}> 님 아래 작업을 확인해주세요."]
-        for text in texts:
-            lines.append(f"• {text}")
-        sections.append("\n".join(lines))
-
-    message = "\n————————————————\n".join(sections)
-    slack_client.chat_postMessage(channel=channel_id, text=message)
+        response = slack_client.chat_postMessage(
+            channel=channel_id,
+            text=f"<@{user_id}> 님 아래 작업을 확인해주세요.",
+        )
+        thread_text = "\n".join(f"• {text}" for text in texts)
+        slack_client.chat_postMessage(
+            channel=channel_id,
+            text=thread_text,
+            thread_ts=response["ts"],
+        )
 
 
 def _get_usergroup_members(
@@ -974,4 +1000,4 @@ if __name__ == "__main__":
     if args.schedule_only:
         run_schedule_feasibility_only(dry_run=args.dry_run)
     else:
-        main()
+        main(dry_run=args.dry_run)

--- a/scripts/manage_tasks_daily.py
+++ b/scripts/manage_tasks_daily.py
@@ -54,6 +54,7 @@ def main():
                     channel_id=pipeline.channel_id,
                     email_to_user_id=email_to_user_id,
                     group_handle=squad.handle,
+                    pm_slack_user_id=squad.pm_slack_user_id,
                 )
 
 
@@ -350,15 +351,16 @@ def alert_no_upcoming_tasks(
     channel_id: str,
     email_to_user_id: dict,
     group_handle: str,
+    pm_slack_user_id: str | None = None,
     **kwargs,
 ):
-    """5일 후에 예정된 작업이 없는 작업자를 예진님에게 알림"""
+    """5일 후에 예정된 작업이 없는 작업자를 PM에게 알림"""
     props = db_config.properties
     if not props.start_date or not props.end_date:
         return
 
-    # 예진님 Slack ID
-    YEJIN_SLACK_ID = "U075PUFNGHX"
+    if not pm_slack_user_id:
+        return
 
     # 영업일 기준 5일 후 날짜 계산
     target_date = get_nth_business_day_from(datetime.now().date(), 5)
@@ -454,7 +456,7 @@ def alert_no_upcoming_tasks(
         weekday_names = ["월", "화", "수", "목", "금", "토", "일"]
         target_weekday = weekday_names[target_date.weekday()]
         text = (
-            f"<@{YEJIN_SLACK_ID}> 5일 후 {target_date.month}/{target_date.day}({target_weekday})에 예정된 작업이 없는 멤버가 있습니다: {members_text}\n"
+            f"<@{pm_slack_user_id}> 5일 후 {target_date.month}/{target_date.day}({target_weekday})에 예정된 작업이 없는 멤버가 있습니다: {members_text}\n"
             "로드맵 점검 부탁드립니다."
         )
         slack_client.chat_postMessage(channel=channel_id, text=text)

--- a/scripts/manage_tasks_daily.py
+++ b/scripts/manage_tasks_daily.py
@@ -348,9 +348,7 @@ def alert_no_tasks(
 
     user_id_to_email = {v: k for k, v in email_to_user_id.items()}
     team_emails = [
-        user_id_to_email[uid]
-        for uid in group_user_ids
-        if uid in user_id_to_email
+        user_id_to_email[uid] for uid in group_user_ids if uid in user_id_to_email
     ]
 
     unassigned_emails = set(team_emails) - assigned_emails
@@ -359,7 +357,10 @@ def alert_no_tasks(
     for email in unassigned_emails:
         slack_user_id = email_to_user_id.get(email)
         items.append(
-            (slack_user_id, "현재 진행중인 작업이 없습니다. 혹시 진행해야 할 업무가 누락되지 않았는지 확인 부탁드립니다.")
+            (
+                slack_user_id,
+                "현재 진행중인 작업이 없습니다. 혹시 진행해야 할 업무가 누락되지 않았는지 확인 부탁드립니다.",
+            )
         )
     return items
 
@@ -423,9 +424,7 @@ def alert_no_upcoming_tasks(
 
     user_id_to_email = {v: k for k, v in email_to_user_id.items()}
     team_emails = [
-        user_id_to_email[uid]
-        for uid in group_user_ids
-        if uid in user_id_to_email
+        user_id_to_email[uid] for uid in group_user_ids if uid in user_id_to_email
     ]
 
     # 5일 후 당일 종일 연차인 멤버 제외

--- a/scripts/post_scrum_message.py
+++ b/scripts/post_scrum_message.py
@@ -155,10 +155,10 @@ def send_team_scrum(
         dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
     """
     # 메인 메시지
-    text = f"{squad.display_name}"
+    text = f"{squad.squad.display_name}"
 
     if dry_run:
-        print(f"\n[{squad.display_name}] 채널: {squad.slack_channel_id}")
+        print(f"\n[{squad.squad.display_name}] 채널: {squad.slack_channel_id}")
         print(text)
 
     # 팀 멤버의 진행 중인 태스크 조회

--- a/scripts/schedule_scrum_mention.py
+++ b/scripts/schedule_scrum_mention.py
@@ -31,7 +31,7 @@ def main():
     # config에서 팀별 멘션 구성 (display_name -> mention, channel_id)
     team_entries = {}
     for squad in scrum.squads:
-        team_entries[squad.display_name] = {
+        team_entries[squad.squad.display_name] = {
             "mention": f"<!subteam^{squad.squad.slack_usergroup_id}>",
             "channel_id": squad.channel_id,
         }

--- a/service/config.py
+++ b/service/config.py
@@ -46,6 +46,7 @@ class Squad:
     """조직 단위 스쿼드"""
 
     handle: str
+    display_name: str
     slack_usergroup_id: str
     notion_db: NotionDBConfig
     pm_slack_user_id: str | None = None
@@ -59,7 +60,6 @@ class ScrumSquadConfig:
     """스크럼 참여 스쿼드 설정"""
 
     squad: Squad
-    display_name: str
     channel_id: str
     pr_warning: bool = True
 
@@ -170,6 +170,7 @@ def _parse_config(raw: dict) -> AppConfig:
             )
         squad = Squad(
             handle=squad_raw["handle"],
+            display_name=squad_raw.get("display_name", squad_raw["handle"]),
             slack_usergroup_id=squad_raw["slack_usergroup_id"],
             notion_db=notion_databases[db_name],
             pm_slack_user_id=squad_raw.get("pm_slack_user_id"),
@@ -187,7 +188,6 @@ def _parse_config(raw: dict) -> AppConfig:
         scrum_squads.append(
             ScrumSquadConfig(
                 squad=squad_by_handle[handle],
-                display_name=ss_raw["display_name"],
                 channel_id=ss_raw["channel_id"],
                 pr_warning=ss_raw.get("pr_warning", True),
             )

--- a/service/config.py
+++ b/service/config.py
@@ -48,6 +48,7 @@ class Squad:
     handle: str
     slack_usergroup_id: str
     notion_db: NotionDBConfig
+    pm_slack_user_id: str | None = None
 
 
 # --- 스크럼 ---
@@ -164,6 +165,7 @@ def _parse_config(raw: dict) -> AppConfig:
             handle=squad_raw["handle"],
             slack_usergroup_id=squad_raw["slack_usergroup_id"],
             notion_db=notion_databases[db_name],
+            pm_slack_user_id=squad_raw.get("pm_slack_user_id"),
         )
         squads.append(squad)
         squad_by_handle[squad.handle] = squad

--- a/service/config.py
+++ b/service/config.py
@@ -85,13 +85,20 @@ class ScrumConfig:
 
 
 @dataclass(frozen=True)
+class PipelineSquad:
+    """파이프라인 내 스쿼드별 알림 설정"""
+
+    squad: Squad
+    alerts: list[str]
+
+
+@dataclass(frozen=True)
 class TaskAlertPipeline:
     """작업 알림 파이프라인"""
 
     name: str
     channel_id: str
-    squads: list[Squad]
-    alerts: list[str]
+    pipeline_squads: list[PipelineSquad]
 
 
 @dataclass(frozen=True)
@@ -199,20 +206,25 @@ def _parse_config(raw: dict) -> AppConfig:
     ta_raw = raw.get("task_alerts", {})
     pipelines = []
     for pl_raw in ta_raw.get("pipelines", []):
-        pl_squads = []
-        for handle in pl_raw.get("squads", []):
+        pipeline_squads = []
+        for sq_raw in pl_raw.get("squads", []):
+            handle = sq_raw["handle"]
             if handle not in squad_by_handle:
                 raise ValueError(
                     f"task_alerts pipeline '{pl_raw['name']}'의 "
                     f"squad handle '{handle}'이 squads에 없습니다."
                 )
-            pl_squads.append(squad_by_handle[handle])
+            pipeline_squads.append(
+                PipelineSquad(
+                    squad=squad_by_handle[handle],
+                    alerts=sq_raw.get("alerts", []),
+                )
+            )
         pipelines.append(
             TaskAlertPipeline(
                 name=pl_raw["name"],
                 channel_id=pl_raw["channel_id"],
-                squads=pl_squads,
-                alerts=pl_raw.get("alerts", []),
+                pipeline_squads=pipeline_squads,
             )
         )
     task_alerts = TaskAlertsConfig(pipelines=pipelines)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,11 +94,11 @@ def test_task_alert_pipelines():
     assert product.name == "제품 본부"
     assert product.channel_id == "C087PDC9VG8"
     assert [ps.squad.handle for ps in product.pipeline_squads] == ["코들", "해커톤", "ie"]
-    ie = product.pipeline_squads[2]
-    assert "alert_overdue_tasks" in ie.alerts
-    assert "alert_no_upcoming_tasks" in ie.alerts
     codle = product.pipeline_squads[0]
-    assert "alert_no_upcoming_tasks" not in codle.alerts
+    assert "alert_overdue_tasks" in codle.alerts
+    assert "alert_no_upcoming_tasks" in codle.alerts
+    ie = product.pipeline_squads[2]
+    assert "alert_no_upcoming_tasks" not in ie.alerts
 
     contents = config.task_alerts.pipelines[1]
     assert contents.name == "콘텐츠 본부"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,7 +78,7 @@ def test_scrum_config():
     assert handles == ["코들", "해커톤", "탐색", "ie"]
 
     codle = config.scrum.squads[0]
-    assert codle.display_name == ":codle_bird: 코들 스쿼드"
+    assert codle.squad.display_name == ":codle_bird: 코들 스쿼드"
     assert codle.channel_id == "C09277NGUET"
     assert codle.pr_warning is True
     assert codle.squad.notion_db.name == "main"
@@ -143,7 +143,7 @@ def test_invalid_scrum_handle_reference():
         "squads": [{"handle": "a", "slack_usergroup_id": "S1", "notion_db": "db1"}],
         "scrum": {
             "squads": [
-                {"handle": "nonexistent", "display_name": "X", "channel_id": "C0"}
+                {"handle": "nonexistent", "channel_id": "C0"}
             ]
         },
     }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,7 +93,11 @@ def test_task_alert_pipelines():
     product = config.task_alerts.pipelines[0]
     assert product.name == "제품 본부"
     assert product.channel_id == "C087PDC9VG8"
-    assert [ps.squad.handle for ps in product.pipeline_squads] == ["코들", "해커톤", "ie"]
+    assert [ps.squad.handle for ps in product.pipeline_squads] == [
+        "코들",
+        "해커톤",
+        "ie",
+    ]
     codle = product.pipeline_squads[0]
     assert "alert_overdue_tasks" in codle.alerts
     assert "alert_no_upcoming_tasks" in codle.alerts
@@ -141,11 +145,7 @@ def test_invalid_scrum_handle_reference():
             }
         },
         "squads": [{"handle": "a", "slack_usergroup_id": "S1", "notion_db": "db1"}],
-        "scrum": {
-            "squads": [
-                {"handle": "nonexistent", "channel_id": "C0"}
-            ]
-        },
+        "scrum": {"squads": [{"handle": "nonexistent", "channel_id": "C0"}]},
     }
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
         yaml.dump(raw, f)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,14 +93,17 @@ def test_task_alert_pipelines():
     product = config.task_alerts.pipelines[0]
     assert product.name == "제품 본부"
     assert product.channel_id == "C087PDC9VG8"
-    assert [s.handle for s in product.squads] == ["코들", "해커톤", "ie"]
-    assert "alert_overdue_tasks" in product.alerts
-    assert "alert_schedule_feasibility" in product.alerts
+    assert [ps.squad.handle for ps in product.pipeline_squads] == ["코들", "해커톤", "ie"]
+    ie = product.pipeline_squads[2]
+    assert "alert_overdue_tasks" in ie.alerts
+    assert "alert_no_upcoming_tasks" in ie.alerts
+    codle = product.pipeline_squads[0]
+    assert "alert_no_upcoming_tasks" not in codle.alerts
 
     contents = config.task_alerts.pipelines[1]
     assert contents.name == "콘텐츠 본부"
-    assert [s.handle for s in contents.squads] == ["콘텐츠"]
-    assert "alert_schedule_feasibility" not in contents.alerts
+    assert [ps.squad.handle for ps in contents.pipeline_squads] == ["콘텐츠"]
+    assert "alert_schedule_feasibility" not in contents.pipeline_squads[0].alerts
 
 
 def test_invalid_squad_db_reference():


### PR DESCRIPTION
## 배경

manage_tasks_daily의 하드코딩된 설정을 config.yaml 기반으로 전환하고, Slack 메시지 형식을 개선.

## 변경사항

- 스쿼드별 PM을 config.yaml의 `pm_slack_user_id`로 관리 (하드코딩된 YEJIN_SLACK_ID 제거)
- pipeline 레벨 alerts → 스쿼드별 alerts 소유로 변경 (스쿼드마다 다른 alert 조합 가능)
- `display_name`을 top-level squad로 통합 (scrum.squads와 중복 제거)
- alert 메시지를 담당자별로 그룹핑: 스쿼드 헤더 → 담당자 멘션 → 스레드에 alert 항목
- 담당자 확인 불가 항목은 PM에게 전달
- `DryRunSlackClient` 래퍼로 dry-run 지원
- `alert_schedule_feasibility` 일시 비활성화
- 인프라 팀 PM → 류호선, `alert_no_upcoming_tasks` → 코들 스쿼드만

## 검증

- `pytest tests/test_config.py` 8개 전부 통과
- `python scripts/manage_tasks_daily.py --dry-run`으로 로컬 검증 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)