### PR TITLE
fix: 스크럼 메시지 slack_channel_id → channel_id 속성명 수정

### DIFF
--- a/scripts/post_scrum_message.py
+++ b/scripts/post_scrum_message.py
@@ -158,7 +158,7 @@ def send_team_scrum(
     text = f"{squad.squad.display_name}"
 
     if dry_run:
-        print(f"\n[{squad.squad.display_name}] 채널: {squad.slack_channel_id}")
+        print(f"\n[{squad.squad.display_name}] 채널: {squad.channel_id}")
         print(text)
 
     # 팀 멤버의 진행 중인 태스크 조회
@@ -212,7 +212,7 @@ def send_team_scrum(
     else:
         # 실제 메시지 발송
         response = slack_client.chat_postMessage(
-            channel=squad.slack_channel_id,
+            channel=squad.channel_id,
             text=text,
         )
         thread_ts = response["ts"]
@@ -220,7 +220,7 @@ def send_team_scrum(
         # 인원별 메시지를 스레드에 발송
         for msg in thread_messages:
             slack_client.chat_postMessage(
-                channel=squad.slack_channel_id,
+                channel=squad.channel_id,
                 thread_ts=thread_ts,
                 text=msg,
             )
@@ -242,11 +242,11 @@ def send_personal_scrum(
     text = personal.name
 
     if dry_run:
-        print(f"\n[{personal.name}] 채널: {personal.slack_channel_id}")
+        print(f"\n[{personal.name}] 채널: {personal.channel_id}")
         print(text)
     else:
         slack_client.chat_postMessage(
-            channel=personal.slack_channel_id,
+            channel=personal.channel_id,
             text=text,
         )
 


### PR DESCRIPTION
## Summary
- `post_scrum_message.py`에서 `slack_channel_id`를 `channel_id`로 수정 (5개소)
- 원인: 678f5f4 리팩터링에서 `ScrumSquadConfig`/`PersonalScrum`의 속성명이 변경되었으나 이 파일의 참조가 누락됨
- 결과: 스크럼 intro 메시지만 발송되고 팀별/개인 스크럼이 `AttributeError`로 중단되는 버그

## Related
- Sentry: WORKFLOW-AUTOMATION-31

## Test plan
- [ ] CI 통과 확인
- [ ] 다음 스크럼 시간(16:00 KST)에 정상 발송 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)