### PR TITLE
fix: data.go.kr API 오류 시 크론 작업 크래시 방지

### DIFF
--- a/api/data_go_kr.py
+++ b/api/data_go_kr.py
@@ -23,4 +23,6 @@ def get_rest_de_info(year: int, month: int):
         "numOfRows": "100",
     }
     response = requests.get(url, params=params, timeout=10)
+    # HTTP 오류 시 명확한 예외 발생 (예: 401 Unauthorized)
+    response.raise_for_status()
     return response.json()

--- a/service/holidays.py
+++ b/service/holidays.py
@@ -23,9 +23,9 @@ def get_public_holidays(year: int, month: int) -> set[str]:
     Note:
         - 근로자의 날(5/1)은 공공데이터에 없으므로 수동 추가
     """
-    data = get_rest_de_info(year, month)
     holidays = set()
     try:
+        data = get_rest_de_info(year, month)
         items = data["response"]["body"]["items"]
         if "item" in items:
             item = items["item"]
@@ -42,8 +42,7 @@ def get_public_holidays(year: int, month: int) -> set[str]:
                     date_str = f"{locdate[:4]}-{locdate[4:6]}-{locdate[6:]}"
                     holidays.add(date_str)
     except Exception as e:
-        print("[ERROR] Parsing holiday info:", e)
-        print("Response data:", data)
+        print(f"[ERROR] 공휴일 조회 실패 (year={year}, month={month}):", e)
 
     # 수동으로 특정 휴일 추가
     if month == 5:


### PR DESCRIPTION
## Summary

Fixes [WORKFLOW-AUTOMATION-2V](https://team-monolith.sentry.io/issues/WORKFLOW-AUTOMATION-2V)

data.go.kr API가 401 Unauthorized를 반환할 때 `response.json()`이 `JSONDecodeError`를 발생시켜 `is_business_day` → 모든 크론 작업이 크래시되는 문제를 수정합니다.

## Changes

- **`api/data_go_kr.py`**: `response.raise_for_status()` 추가 — HTTP 오류를 `JSONDecodeError` 대신 명확한 `HTTPError` 예외로 변환
- **`service/holidays.py`**: `get_rest_de_info()` 호출을 기존 try/except 블록 내부로 이동 — API 오류 시 빈 공휴일 집합을 반환하여 크론 작업이 정상 실행되도록 처리

## Test plan

- [x] `black .` — 포맷 변경 없음
- [x] `pytest` — 42 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)