### PR TITLE
fix: 근무 현황 리포트 날짜가 하루 밀리는 버그 수정

### DIFF
--- a/scripts/github_admin/add_ruleset.py
+++ b/scripts/github_admin/add_ruleset.py
@@ -267,9 +267,7 @@ def apply_ruleset_to_repos(
 
         if skip_repos and repo_name in skip_repos:
             ruleset_name = ruleset_template["name"]
-            exists, ruleset_id = find_ruleset_by_name(
-                org_name, repo_name, ruleset_name
-            )
+            exists, ruleset_id = find_ruleset_by_name(org_name, repo_name, ruleset_name)
             if exists and ruleset_id:
                 if dry_run:
                     print(

--- a/scripts/notify_upcoming_workevent.py
+++ b/scripts/notify_upcoming_workevent.py
@@ -8,11 +8,13 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import argparse
 import os
 from collections import defaultdict
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Dict, List, Set, Tuple
 
 from dotenv import load_dotenv
 from slack_sdk import WebClient
+
+KST = timezone(timedelta(hours=9))
 
 from api.wantedspace import get_workevent, get_event_codes
 
@@ -195,7 +197,7 @@ def main():
     p.add_argument("--dry-run", action="store_true", help="콘솔 출력만")
     args = p.parse_args()
 
-    today = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
+    today = datetime.now(KST).replace(hour=0, minute=0, second=0, microsecond=0)
     end_dt = today + timedelta(days=args.days - 1)
 
     try:

--- a/scripts/notify_worktime_left.py
+++ b/scripts/notify_worktime_left.py
@@ -6,12 +6,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import calendar
 import os
 import argparse
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import time
 
 from dotenv import load_dotenv
 from slack_sdk import WebClient
 import tabulate
+
+KST = timezone(timedelta(hours=9))
 
 from api.wantedspace import get_workevent, get_worktime
 from service.holidays import get_public_holidays
@@ -60,7 +62,7 @@ def main():
     email_to_user_id = get_email_to_user_id(slack_client)
 
     # 오늘(시분초=0)
-    today = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
+    today = datetime.now(KST).replace(hour=0, minute=0, second=0, microsecond=0)
 
     # 2) 이번 달 1일부터 "어제"까지 근무시간(WorkTime) 조회
     email_to_worktime = {}
@@ -225,7 +227,7 @@ def get_monthly_vacation_breakdown(year: int, month: int, workevent):
     - today_days (오늘)
     - future_days (앞으로)
     """
-    today = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
+    today = datetime.now(KST).replace(hour=0, minute=0, second=0, microsecond=0)
     _, last_day = calendar.monthrange(year, month)
     first_day_dt = datetime(year, month, 1)
     last_day_dt = datetime(year, month, last_day)

--- a/scripts/notify_worktime_left.py
+++ b/scripts/notify_worktime_left.py
@@ -284,7 +284,7 @@ def get_monthly_vacation_breakdown(year: int, month: int, workevent):
         if frac <= 0:
             continue
 
-        dt = datetime(year, month, d)
+        dt = datetime(year, month, d, tzinfo=KST)
         if dt < today:
             used_days += frac
         elif dt == today:


### PR DESCRIPTION
## Summary
- `datetime.today()` → `datetime.now(KST)` 변경으로 UTC 컨테이너에서 날짜가 하루 밀리는 문제 수정
- 영향 파일: `notify_worktime_left.py` (2곳), `notify_upcoming_workevent.py` (1곳)
- `scheduler.py`에서 이미 사용 중인 KST 패턴을 스크립트에도 적용

## Root Cause
스케줄러는 KST 8:00에 실행되지만 (= UTC 23:00 전날), 스크립트 내부에서 `datetime.today()`가 시스템 타임존(UTC)을 사용하여 전날 날짜를 반환

## Test plan
- [ ] CI 테스트 통과 확인
- [ ] 다음 영업일 8:45 KST에 근무 현황 리포트가 올바른 날짜로 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Notion: https://www.notion.so/team-mono/3361cc820da6816cb43bc79c5bdf1939