### PR TITLE
fix: ClientConnectionResetError 로그 이벤트 Sentry 필터링

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,12 @@ def _before_send(event, hint):
         _, exc_value, _ = hint["exc_info"]
         if isinstance(exc_value, ClientConnectionResetError):
             return None
+    # 로그 이벤트 필터 (Slack Bolt가 내부적으로 catch 후 로깅하는 경우)
+    message = (event.get("logentry") or {}).get("message", "")
+    if not message:
+        message = event.get("message", "")
+    if "ClientConnectionResetError" in message:
+        return None
     return event
 
 


### PR DESCRIPTION
## Summary
- `_before_send` 훅에 로그 이벤트 기반 `ClientConnectionResetError` 필터 추가
- 기존 필터는 `exc_info` 기반 예외만 차단했으나, Slack Bolt SDK가 내부 catch 후 로그로 기록하는 이벤트가 LoggingIntegration을 통해 Sentry에 전달되어 ~98건의 1회성 노이즈 이슈가 누적되는 문제 해결
- `logentry.message` 및 `message` 필드에서 `ClientConnectionResetError` 문자열 포함 여부를 체크하여 드롭

## Test plan
- [ ] CI (pytest, Black) 통과 확인
- [ ] 배포 후 Sentry에서 새로운 ClientConnectionResetError 로그 이슈가 생성되지 않는지 확인
- [ ] 기존 ~98건의 미해결 이슈 일괄 resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)