### PR TITLE
feat: 크론 작업 전체에 슬래시 커맨드 추가

### DIFF
--- a/app/general.py
+++ b/app/general.py
@@ -4,6 +4,7 @@
 
 import asyncio
 from datetime import datetime, timedelta
+import importlib
 import logging
 
 from slack_bolt.async_app import AsyncBoltContext, AsyncSetStatus
@@ -203,3 +204,26 @@ def register_general_handlers(app, assistant):
             summarize_deployment.summarize_deployment,
             caller_slack_user_id=body.get("user_id"),
         )
+
+    # 크론 작업들에 대한 슬래시 커맨드 일괄 등록
+    _CRON_COMMANDS = [
+        ("/validate-customer-reports", "scripts.validate_customer_reports", "main", "고객 보고서 검증"),
+        ("/manage-tasks-daily", "scripts.manage_tasks_daily", "main", "일일 작업 알림 처리"),
+        ("/notify-upcoming-workevent", "scripts.notify_upcoming_workevent", "main", "근태 예정 알림 생성"),
+        ("/notify-worktime-left", "scripts.notify_worktime_left", "main", "잔여 근무시간 계산"),
+        ("/collect-review-stats", "scripts.collect_review_stats", "main", "리뷰 통계 수집"),
+        ("/collect-coding-rule-feedbacks", "scripts.collect_coding_rule_feedbacks", "main", "코딩 규칙 피드백 수집"),
+        ("/post-scrum-message", "scripts.post_scrum_message", "main", "스크럼 메시지 발송"),
+        ("/schedule-scrum-mention", "scripts.schedule_scrum_mention", "main", "스크럼 멘션 발송"),
+    ]
+
+    def _register_cron_command(command_name, module_path, func_name, description):
+        @app.command(command_name)
+        async def handler(ack, body):
+            await ack(text=f"⏳ {description} 중입니다…")
+            module = importlib.import_module(module_path)
+            func = getattr(module, func_name)
+            await asyncio.to_thread(func)
+
+    for cmd, mod, fn, desc in _CRON_COMMANDS:
+        _register_cron_command(cmd, mod, fn, desc)

--- a/app/general.py
+++ b/app/general.py
@@ -207,14 +207,54 @@ def register_general_handlers(app, assistant):
 
     # 크론 작업들에 대한 슬래시 커맨드 일괄 등록
     _CRON_COMMANDS = [
-        ("/validate-customer-reports", "scripts.validate_customer_reports", "main", "고객 보고서 검증"),
-        ("/manage-tasks-daily", "scripts.manage_tasks_daily", "main", "일일 작업 알림 처리"),
-        ("/notify-upcoming-workevent", "scripts.notify_upcoming_workevent", "main", "근태 예정 알림 생성"),
-        ("/notify-worktime-left", "scripts.notify_worktime_left", "main", "잔여 근무시간 계산"),
-        ("/collect-review-stats", "scripts.collect_review_stats", "main", "리뷰 통계 수집"),
-        ("/collect-coding-rule-feedbacks", "scripts.collect_coding_rule_feedbacks", "main", "코딩 규칙 피드백 수집"),
-        ("/post-scrum-message", "scripts.post_scrum_message", "main", "스크럼 메시지 발송"),
-        ("/schedule-scrum-mention", "scripts.schedule_scrum_mention", "main", "스크럼 멘션 발송"),
+        (
+            "/validate-customer-reports",
+            "scripts.validate_customer_reports",
+            "main",
+            "고객 보고서 검증",
+        ),
+        (
+            "/manage-tasks-daily",
+            "scripts.manage_tasks_daily",
+            "main",
+            "일일 작업 알림 처리",
+        ),
+        (
+            "/notify-upcoming-workevent",
+            "scripts.notify_upcoming_workevent",
+            "main",
+            "근태 예정 알림 생성",
+        ),
+        (
+            "/notify-worktime-left",
+            "scripts.notify_worktime_left",
+            "main",
+            "잔여 근무시간 계산",
+        ),
+        (
+            "/collect-review-stats",
+            "scripts.collect_review_stats",
+            "main",
+            "리뷰 통계 수집",
+        ),
+        (
+            "/collect-coding-rule-feedbacks",
+            "scripts.collect_coding_rule_feedbacks",
+            "main",
+            "코딩 규칙 피드백 수집",
+        ),
+        (
+            "/post-scrum-message",
+            "scripts.post_scrum_message",
+            "main",
+            "스크럼 메시지 발송",
+        ),
+        (
+            "/schedule-scrum-mention",
+            "scripts.schedule_scrum_mention",
+            "main",
+            "스크럼 멘션 발송",
+        ),
     ]
 
     def _register_cron_command(command_name, module_path, func_name, description):

--- a/app/general.py
+++ b/app/general.py
@@ -10,7 +10,7 @@ import logging
 from slack_bolt.async_app import AsyncBoltContext, AsyncSetStatus
 from slack_sdk.web.async_client import AsyncWebClient
 
-from . import analyze_oom, route_bug, route_dev_env_infra_bug, summarize_deployment
+from . import analyze_oom, route_bug, route_dev_env_infra_bug
 from .common import (
     KST,
     answer,
@@ -188,24 +188,11 @@ def register_general_handlers(app, assistant):
             tools,
         )
 
-    @app.command("/summarize-deployment")
-    async def on_summarize_deployment(ack, body):
-        """
-        /summarize-deployment 명령어를 처리하는 핸들러
-        """
-        await ack(text="⏳ 배포 요약을 작성 중입니다…")
-
-        # summarize_deployment 가 Blocking IO 이므로
-        # asyncio.to_thread 를 사용하여 비동기적으로 실행
-        # 그렇지 않으면 ack 응답이 3초안에 날아가지 않아
-        # dispatch_failed 오류가 발생함.
-        # https://chatgpt.com/share/6805f405-36b0-8002-a298-ac2cefb12b0b
-        await asyncio.to_thread(
-            summarize_deployment.summarize_deployment,
-            caller_slack_user_id=body.get("user_id"),
-        )
-
     # 크론 작업들에 대한 슬래시 커맨드 일괄 등록
+    # 각 튜플: (command, module_path, func_name, description[, body_kwargs])
+    # body_kwargs 는 선택사항으로, body 에서 값을 꺼내 함수 키워드 인자로
+    # 전달할 매핑입니다.  예: {"caller_slack_user_id": "user_id"} 이면
+    # func(caller_slack_user_id=body.get("user_id")) 로 호출됩니다.
     _CRON_COMMANDS = [
         (
             "/validate-customer-reports",
@@ -255,15 +242,28 @@ def register_general_handlers(app, assistant):
             "main",
             "스크럼 멘션 발송",
         ),
+        (
+            "/summarize-deployment",
+            "app.summarize_deployment",
+            "summarize_deployment",
+            "배포 요약을 작성",
+            {"caller_slack_user_id": "user_id"},
+        ),
     ]
 
-    def _register_cron_command(command_name, module_path, func_name, description):
+    def _register_cron_command(
+        command_name, module_path, func_name, description, body_kwargs=None
+    ):
         @app.command(command_name)
         async def handler(ack, body):
             await ack(text=f"⏳ {description} 중입니다…")
             module = importlib.import_module(module_path)
             func = getattr(module, func_name)
-            await asyncio.to_thread(func)
+            kwargs = {
+                kwarg: body.get(body_key)
+                for kwarg, body_key in (body_kwargs or {}).items()
+            }
+            await asyncio.to_thread(func, **kwargs)
 
-    for cmd, mod, fn, desc in _CRON_COMMANDS:
-        _register_cron_command(cmd, mod, fn, desc)
+    for cmd, mod, fn, desc, *rest in _CRON_COMMANDS:
+        _register_cron_command(cmd, mod, fn, desc, rest[0] if rest else None)


### PR DESCRIPTION
## Summary
- 기존 `/summarize-deployment` 외 나머지 8개 크론 작업에 수동 트리거용 슬래시 커맨드 추가
- 데이터 기반 팩토리 패턴으로 반복 코드 없이 일괄 등록
- 기존 패턴(`asyncio.to_thread`)을 그대로 따라 blocking IO 안전하게 처리

### 추가된 커맨드
| 커맨드 | 크론 작업 | 설명 |
|--------|----------|------|
| `/validate-customer-reports` | validate_customer_reports | 고객 보고서 검증 |
| `/manage-tasks-daily` | manage_tasks_daily | 일일 작업 알림 처리 |
| `/notify-upcoming-workevent` | notify_upcoming_workevent | 근태 예정 알림 생성 |
| `/notify-worktime-left` | notify_worktime_left | 잔여 근무시간 계산 |
| `/collect-review-stats` | collect_review_stats | 리뷰 통계 수집 |
| `/collect-coding-rule-feedbacks` | collect_coding_rule_feedbacks | 코딩 규칙 피드백 수집 |
| `/post-scrum-message` | post_scrum_message | 스크럼 메시지 발송 |
| `/schedule-scrum-mention` | schedule_scrum_mention | 스크럼 멘션 발송 |

## Note
Slack 앱 설정에서 각 커맨드를 등록해야 실제로 동작합니다 (api.slack.com > Slash Commands).

## Test plan
- [ ] Slack 앱 설정에 커맨드 8개 등록
- [ ] ArgoCD 싱크 후 `/notify-worktime-left` 등 커맨드 실행 테스트
- [ ] 응답 메시지가 정상적으로 오는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)