### PR TITLE
fix: 탐색 스쿼드 스크럼 중단 버그 수정

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,7 +44,7 @@ notion_databases:
       title: "작업"
       status: "진행 상태"
       assignee: "담당자"
-      timeline: "작업 일정"
+      timeline: "타임라인"
     pending_statuses: []
     in_progress_statuses: ["진행 중", "테스트 중"]
 

--- a/config.yaml
+++ b/config.yaml
@@ -44,7 +44,7 @@ notion_databases:
       title: "작업"
       status: "진행 상태"
       assignee: "담당자"
-      timeline: "마감일"
+      timeline: "작업 일정"
     pending_statuses: []
     in_progress_statuses: ["진행 중", "테스트 중"]
 

--- a/scripts/post_scrum_message.py
+++ b/scripts/post_scrum_message.py
@@ -63,17 +63,23 @@ def main():
 
     # 2. 스쿼드별 스크럼
     for squad in scrum.squads:
-        send_team_scrum(
-            notion,
-            slack_client,
-            email_to_user_id,
-            squad,
-            args.dry_run,
-        )
+        try:
+            send_team_scrum(
+                notion,
+                slack_client,
+                email_to_user_id,
+                squad,
+                args.dry_run,
+            )
+        except Exception as e:
+            print(f"Error in send_team_scrum for {squad.squad.display_name}: {e}")
 
     # 3. 개인 스크럼
     for personal in scrum.personal_scrums:
-        send_personal_scrum(slack_client, personal, args.dry_run)
+        try:
+            send_personal_scrum(slack_client, personal, args.dry_run)
+        except Exception as e:
+            print(f"Error in send_personal_scrum for {personal.name}: {e}")
 
     if args.dry_run:
         print("\n=== DRY RUN COMPLETED ===")

--- a/scripts/post_scrum_message.py
+++ b/scripts/post_scrum_message.py
@@ -12,6 +12,7 @@ import os
 from datetime import datetime
 from typing import Any
 
+import sentry_sdk
 from dotenv import load_dotenv
 from notion_client import Client as NotionClient
 from slack_sdk import WebClient
@@ -72,6 +73,7 @@ def main():
                 args.dry_run,
             )
         except Exception as e:
+            sentry_sdk.capture_exception(e)
             print(f"Error in send_team_scrum for {squad.squad.display_name}: {e}")
 
     # 3. 개인 스크럼
@@ -79,6 +81,7 @@ def main():
         try:
             send_personal_scrum(slack_client, personal, args.dry_run)
         except Exception as e:
+            sentry_sdk.capture_exception(e)
             print(f"Error in send_personal_scrum for {personal.name}: {e}")
 
     if args.dry_run:


### PR DESCRIPTION
## Summary
- 탐색(explore) Notion DB의 타임라인 속성명이 `마감일`에서 `작업 일정`으로 변경되어, 스크럼 메시지 발송 시 `KeyError`가 발생하고 이후 스쿼드(인프라, CTO)가 누락되는 문제를 수정
- 스쿼드별 try/except를 추가하여 한 스쿼드에서 오류가 발생해도 나머지 스쿼드는 정상 발송되도록 개선

## Changes

### config.yaml
- explore DB의 `timeline` 속성명을 `"마감일"` → `"작업 일정"`으로 수정

### scripts/post_scrum_message.py
- `send_team_scrum()`, `send_personal_scrum()` 호출에 try/except 추가로 격리

## Test plan
- [ ] 다음 스크럼 발송 시 탐색 스쿼드, 인프라 팀, CTO 메시지가 정상 발송되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)