### PR TITLE
feat: 배포 담당자 로테이션 자동화

### DIFF
--- a/app/general.py
+++ b/app/general.py
@@ -310,6 +310,12 @@ def register_general_handlers(app, assistant):
             "배포 요약을 작성",
             {"caller_slack_user_id": "user_id"},
         ),
+        (
+            "/announce-deployment-rotation",
+            "scripts.announce_deployment_rotation",
+            "main",
+            "배포 담당자 공지",
+        ),
     ]
 
     def _register_cron_command(

--- a/app/summarize_deployment.py
+++ b/app/summarize_deployment.py
@@ -34,6 +34,7 @@ from slack_sdk import WebClient
 import dotenv
 
 from service.config import NotionDBConfig, load_config
+from service.deployment_rotation import get_todays_deployer
 from service.slack import get_email_to_user_id
 
 dotenv.load_dotenv()
@@ -141,6 +142,13 @@ def summarize_deployment(
 
     today_str = datetime.now().date().isoformat()
 
+    # 오늘의 배포 담당자 계산
+    deployer_mention = ""
+    if config.deployment_rotation:
+        deployer = get_todays_deployer(config.deployment_rotation.members)
+        if deployer:
+            deployer_mention = f" (배포 담당자: <@{deployer}>)"
+
     # 제품 본부 파이프라인의 스쿼드 DB에서 배포 예정 과업 조회
     product_pipeline = next(
         p for p in config.task_alerts.pipelines if p.name == "제품 본부"
@@ -159,7 +167,7 @@ def summarize_deployment(
         # 오늘 배포할 과업이 없으면 Slack 메시지 전송 후 종료
         slack_client.chat_postMessage(
             channel=SLACK_CHANNEL_ID,
-            text="오늘 예정된 배포가 없네요. 놓치신 과업은 없으실까요?\n(/summarize-deployment 명령어를 사용해보세요!)",
+            text=f"오늘 예정된 배포가 없네요.{deployer_mention} 놓치신 과업은 없으실까요?\n(/summarize-deployment 명령어를 사용해보세요!)",
         )
         print("No tasks scheduled for deployment today.")
         return
@@ -169,9 +177,11 @@ def summarize_deployment(
 
     # 메시지 헤더 & 호출자 멘션
     if caller_slack_user_id:
-        message = f"오늘 배포 예정 과업! (by <@{caller_slack_user_id}>)\n"
+        message = (
+            f"오늘 배포 예정 과업!{deployer_mention} (by <@{caller_slack_user_id}>)\n"
+        )
     else:
-        message = "오늘 배포 예정 과업!\n"
+        message = f"오늘 배포 예정 과업!{deployer_mention}\n"
 
     task_index = 0
     for task in tasks:
@@ -235,7 +245,7 @@ def summarize_deployment(
     if task_index == 0:
         slack_client.chat_postMessage(
             channel=SLACK_CHANNEL_ID,
-            text="오늘 예정된 배포가 없네요. 놓치신 과업은 없으실까요?\n(/summarize-deployment 명령어를 사용해보세요!)",
+            text=f"오늘 예정된 배포가 없네요.{deployer_mention} 놓치신 과업은 없으실까요?\n(/summarize-deployment 명령어를 사용해보세요!)",
         )
         print("No tasks with open PRs scheduled for deployment today.")
         return

--- a/config.yaml
+++ b/config.yaml
@@ -148,6 +148,13 @@ task_alerts:
             - alert_no_due_tasks
             - alert_no_tasks
 
+deployment_rotation:
+  channel_id: "C02VA2LLXH9"
+  members:
+    - "U02JLCWGETT"  # 배영빈
+    - "U07RP7U3FPU"
+    - "U02PFUPCJNM"  # 류호선
+
 scheduled_jobs:
   - name: validate_customer_reports
     module: scripts.validate_customer_reports
@@ -229,3 +236,12 @@ scheduled_jobs:
       minute: 30
       day_of_week: mon-fri
     business_day_only: true
+
+  - name: announce_deployment_rotation
+    module: scripts.announce_deployment_rotation
+    function: main
+    cron:
+      hour: 9
+      minute: 0
+      day: 1
+    business_day_only: false

--- a/scripts/announce_deployment_rotation.py
+++ b/scripts/announce_deployment_rotation.py
@@ -1,0 +1,48 @@
+"""
+매월 1일 배포 담당자 스케줄 공지
+
+해당 월의 요일별 배포 담당자를 계산하여 공지-배포 채널에 안내 메시지를 전송합니다.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import os
+from datetime import date
+
+from dotenv import load_dotenv
+from slack_sdk import WebClient
+
+from service.config import load_config
+from service.deployment_rotation import get_weekday_schedule, WEEKDAY_NAMES
+
+load_dotenv()
+
+
+def main():
+    config = load_config()
+    rotation = config.deployment_rotation
+    if not rotation:
+        print("deployment_rotation 설정이 없습니다.")
+        return
+
+    today = date.today()
+    year, month = today.year, today.month
+    schedule = get_weekday_schedule(year, month, rotation.members)
+
+    lines = [f"\U0001f4cb {month}월 배포 담당자 안내\n"]
+    for weekday_idx in range(5):
+        user_id = schedule[weekday_idx]
+        lines.append(f"{WEEKDAY_NAMES[weekday_idx]}: <@{user_id}>")
+
+    message = "\n".join(lines)
+
+    slack_client = WebClient(token=os.environ["SLACK_BOT_TOKEN"])
+    slack_client.chat_postMessage(channel=rotation.channel_id, text=message)
+    print(f"{year}년 {month}월 배포 담당자 공지 전송 완료.")
+
+
+if __name__ == "__main__":
+    main()

--- a/service/config.py
+++ b/service/config.py
@@ -108,6 +108,17 @@ class TaskAlertsConfig:
     pipelines: list[TaskAlertPipeline]
 
 
+# --- 배포 담당자 로테이션 ---
+
+
+@dataclass(frozen=True)
+class DeploymentRotationConfig:
+    """배포 담당자 로테이션 설정"""
+
+    channel_id: str
+    members: list[str]
+
+
 # --- 스케줄 작업 ---
 
 
@@ -133,6 +144,7 @@ class AppConfig:
     squads: list[Squad]
     scrum: ScrumConfig
     task_alerts: TaskAlertsConfig
+    deployment_rotation: DeploymentRotationConfig | None = None
     scheduled_jobs: list[ScheduledJobConfig] = field(default_factory=list)
 
 
@@ -229,6 +241,15 @@ def _parse_config(raw: dict) -> AppConfig:
         )
     task_alerts = TaskAlertsConfig(pipelines=pipelines)
 
+    # Deployment rotation
+    dr_raw = raw.get("deployment_rotation")
+    deployment_rotation = None
+    if dr_raw:
+        deployment_rotation = DeploymentRotationConfig(
+            channel_id=dr_raw["channel_id"],
+            members=dr_raw["members"],
+        )
+
     # Scheduled jobs
     scheduled_jobs = [
         ScheduledJobConfig(
@@ -246,6 +267,7 @@ def _parse_config(raw: dict) -> AppConfig:
         squads=squads,
         scrum=scrum,
         task_alerts=task_alerts,
+        deployment_rotation=deployment_rotation,
         scheduled_jobs=scheduled_jobs,
     )
 

--- a/service/deployment_rotation.py
+++ b/service/deployment_rotation.py
@@ -1,0 +1,50 @@
+"""
+배포 담당자 로테이션 서비스
+
+요일별 배포 담당자를 round-robin으로 계산합니다.
+"""
+
+from datetime import date
+
+from service.business_days import is_business_day
+
+WEEKDAY_NAMES = ["월", "화", "수", "목", "금"]
+
+
+def _get_rotation_offset(year: int, month: int, num_members: int) -> int:
+    """월별 로테이션 오프셋 계산"""
+    return (year * 12 + month) % num_members
+
+
+def get_weekday_schedule(year: int, month: int, members: list[str]) -> dict[int, str]:
+    """해당 월의 요일별 배포 담당자 매핑 반환
+
+    Args:
+        year: 연도
+        month: 월
+        members: 배포 담당자 Slack user ID 목록
+
+    Returns:
+        dict[int, str]: 요일 인덱스(0=월..4=금) -> Slack user ID
+    """
+    offset = _get_rotation_offset(year, month, len(members))
+    return {i: members[(i + offset) % len(members)] for i in range(5)}
+
+
+def get_todays_deployer(members: list[str]) -> str | None:
+    """오늘의 배포 담당자를 반환. 영업일이 아니면 None.
+
+    Args:
+        members: 배포 담당자 Slack user ID 목록
+
+    Returns:
+        str | None: 오늘의 배포 담당자 Slack user ID, 영업일이 아니면 None
+    """
+    today = date.today()
+    if not is_business_day(today):
+        return None
+    weekday = today.weekday()  # 0=월..4=금
+    if weekday >= 5:
+        return None
+    schedule = get_weekday_schedule(today.year, today.month, members)
+    return schedule[weekday]

--- a/tests/test_deployment_rotation.py
+++ b/tests/test_deployment_rotation.py
@@ -1,0 +1,90 @@
+"""배포 담당자 로테이션 서비스 테스트"""
+
+from datetime import date
+from unittest.mock import patch
+
+from service.deployment_rotation import (
+    _get_rotation_offset,
+    get_weekday_schedule,
+    get_todays_deployer,
+    WEEKDAY_NAMES,
+)
+
+MEMBERS = ["U_A", "U_B", "U_C"]
+
+
+def test_weekday_names():
+    """한국어 요일 이름 검증"""
+    assert WEEKDAY_NAMES == ["월", "화", "수", "목", "금"]
+
+
+def test_rotation_offset_deterministic():
+    """같은 연월이면 항상 같은 오프셋"""
+    assert _get_rotation_offset(2026, 4, 3) == _get_rotation_offset(2026, 4, 3)
+
+
+def test_rotation_offset_changes_monthly():
+    """월이 바뀌면 오프셋이 변경될 수 있음"""
+    offsets = {_get_rotation_offset(2026, m, 3) for m in range(1, 13)}
+    # 3명이면 12개월 중 최소 2가지 이상의 오프셋이 나와야 함
+    assert len(offsets) >= 2
+
+
+def test_get_weekday_schedule_covers_all_weekdays():
+    """스케줄이 월~금 5일을 모두 포함"""
+    schedule = get_weekday_schedule(2026, 4, MEMBERS)
+    assert set(schedule.keys()) == {0, 1, 2, 3, 4}
+
+
+def test_get_weekday_schedule_uses_all_members():
+    """멤버 수가 5 미만이면 일부 멤버가 여러 요일에 배정됨"""
+    schedule = get_weekday_schedule(2026, 4, MEMBERS)
+    assigned = set(schedule.values())
+    # 3명이 5요일을 커버하므로 모든 멤버가 1번 이상 배정
+    assert assigned == set(MEMBERS)
+
+
+def test_get_weekday_schedule_round_robin():
+    """라운드 로빈으로 순환 배정 확인"""
+    schedule = get_weekday_schedule(2026, 4, MEMBERS)
+    offset = _get_rotation_offset(2026, 4, len(MEMBERS))
+    for i in range(5):
+        expected = MEMBERS[(i + offset) % len(MEMBERS)]
+        assert schedule[i] == expected
+
+
+def test_get_todays_deployer_on_business_day():
+    """영업일에는 배포 담당자 반환"""
+    # 2026-04-06은 월요일
+    with patch("service.deployment_rotation.date") as mock_date, patch(
+        "service.deployment_rotation.is_business_day", return_value=True
+    ):
+        mock_date.today.return_value = date(2026, 4, 6)
+        result = get_todays_deployer(MEMBERS)
+        assert result is not None
+        assert result in MEMBERS
+
+
+def test_get_todays_deployer_on_non_business_day():
+    """비영업일(주말/공휴일)에는 None 반환"""
+    with patch("service.deployment_rotation.date") as mock_date, patch(
+        "service.deployment_rotation.is_business_day", return_value=False
+    ):
+        mock_date.today.return_value = date(2026, 4, 5)  # 일요일
+        result = get_todays_deployer(MEMBERS)
+        assert result is None
+
+
+def test_schedule_consistency_across_month():
+    """같은 월 내에서는 스케줄이 일관됨"""
+    s1 = get_weekday_schedule(2026, 4, MEMBERS)
+    s2 = get_weekday_schedule(2026, 4, MEMBERS)
+    assert s1 == s2
+
+
+def test_schedule_different_months():
+    """다른 월에는 스케줄이 다를 수 있음 (offset이 달라지므로)"""
+    schedules = [get_weekday_schedule(2026, m, MEMBERS) for m in range(1, 13)]
+    # 12개월 중 최소 2가지 이상의 다른 스케줄이 있어야 함
+    unique = len(set(tuple(s.items()) for s in schedules))
+    assert unique >= 2


### PR DESCRIPTION
## Summary
- 매월 1일 요일별 배포 담당자 스케줄을 공지-배포 채널(C02VA2LLXH9)에 자동 공지
- 매일 배포 알림(summarize_deployment)에 당일 배포 담당자를 태그
- config.yaml에서 로테이션 멤버 풀 관리 가능

## Changes
- `config.yaml`: `deployment_rotation` 설정 및 `announce_deployment_rotation` 크론 작업 추가
- `service/config.py`: `DeploymentRotationConfig` 데이터클래스 및 파싱 로직 추가
- `service/deployment_rotation.py`: round-robin 기반 요일별 배포 담당자 계산 서비스
- `scripts/announce_deployment_rotation.py`: 월간 배포 담당자 스케줄 공지 스크립트
- `app/summarize_deployment.py`: 배포 알림 메시지에 당일 배포 담당자 멘션 추가
- `app/general.py`: `/announce-deployment-rotation` 슬래시 커맨드 등록
- `tests/test_deployment_rotation.py`: 로테이션 로직 단위 테스트 (10개)

## Algorithm
- offset = (year * 12 + month) % len(members)
- 각 요일 i (0=월..4=금): assigned = members[(i + offset) % len(members)]
- 월마다 오프셋이 변경되어 동일 요일에 다른 담당자가 배정됨

## Test plan
- [x] `pytest tests/test_config.py` — 기존 설정 테스트 통과 (8/8)
- [x] `pytest tests/test_deployment_rotation.py` — 로테이션 로직 테스트 통과 (10/10)
- [ ] `/announce-deployment-rotation` 슬래시 커맨드 동작 확인
- [ ] 배포 알림에 담당자 멘션 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)