### PR TITLE
fix: 탐색 스쿼드 스크럼 누락 수정

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,7 +46,7 @@ notion_databases:
       assignee: "담당자"
       timeline: "타임라인"
     pending_statuses: []
-    in_progress_statuses: ["진행 중", "테스트 중"]
+    in_progress_statuses: ["진행 중", "In Progress"]
 
   contents:
     data_source_id: "fecd7fca-8280-4f02-b78f-7fa720f53aa6"


### PR DESCRIPTION
## Summary
- explore DB의 `in_progress_statuses`에 존재하지 않는 `"테스트 중"` 상태가 포함되어 있어 Notion API가 400 에러를 반환
- 이로 인해 매일 스크럼 발송 시 탐색 스쿼드 쓰레드가 누락됨
- 유효한 상태값 `"In Progress"`로 교체

## Root Cause
explore Notion DB의 진행 상태 속성에는 `"테스트 중"` 옵션이 없음. 유효한 옵션: "시작 전", "진행 중", "완료", "중단", "To-do", "In Progress", "Complete"

## Test plan
- [ ] 배포 후 스크럼 발송 시 탐색 스쿼드 쓰레드가 정상 생성되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)