### PR TITLE
feat: 스크럼 PR 경고에서 기획자/PM 제외

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -93,7 +93,7 @@ squads:
 scrum:
   pr_warning_excluded_members:
     - "U075PUFNGHX"  # 예진 이 (코들 PM)
-    # 전종현 (해커톤 기획자) - user ID 확인 후 추가 예정
+    - "U02FXQMJ88G"  # 전종현 (기획자)
 
   squads:
     - handle: "코들"

--- a/config.yaml
+++ b/config.yaml
@@ -91,6 +91,10 @@ squads:
     notion_db: contents
 
 scrum:
+  pr_warning_excluded_members:
+    - "U075PUFNGHX"  # 예진 이 (코들 PM)
+    # 전종현 (해커톤 기획자) - user ID 확인 후 추가 예정
+
   squads:
     - handle: "코들"
       channel_id: "C09277NGUET"

--- a/scripts/post_scrum_message.py
+++ b/scripts/post_scrum_message.py
@@ -70,6 +70,7 @@ def main():
                 slack_client,
                 email_to_user_id,
                 squad,
+                scrum.pr_warning_excluded_members,
                 args.dry_run,
             )
         except Exception as e:
@@ -151,6 +152,7 @@ def send_team_scrum(
     slack_client: WebClient,
     email_to_user_id: dict[str, str],
     squad: ScrumSquadConfig,
+    pr_warning_excluded_members: list[str],
     dry_run: bool = False,
 ):
     """
@@ -161,6 +163,7 @@ def send_team_scrum(
         slack_client: Slack WebClient
         email_to_user_id: 이메일 -> Slack User ID 매핑
         squad: 스쿼드 설정
+        pr_warning_excluded_members: PR 경고 제외 대상 Slack User ID 목록
         dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
     """
     # 메인 메시지
@@ -198,9 +201,15 @@ def send_team_scrum(
         # 담당자 이름 (첫 번째 태스크에서 가져옴)
         assignee_name = tasks[0]["assignee_name"]
 
+        # 기획자/PM은 PR 경고에서 제외
+        user_id = email_to_user_id.get(email)
+        is_excluded = user_id in pr_warning_excluded_members
+
         # PR 경고 활성화 여부
         pr_warning_enabled = (
-            squad.pr_warning and squad.squad.notion_db.properties.pr is not None
+            squad.pr_warning
+            and squad.squad.notion_db.properties.pr is not None
+            and not is_excluded
         )
 
         # 인원별 메시지 생성

--- a/service/config.py
+++ b/service/config.py
@@ -79,6 +79,7 @@ class ScrumConfig:
 
     squads: list[ScrumSquadConfig]
     personal_scrums: list[PersonalScrum]
+    pr_warning_excluded_members: list[str] = field(default_factory=list)
 
 
 # --- 작업 알림 ---
@@ -212,7 +213,11 @@ def _parse_config(raw: dict) -> AppConfig:
         )
         for p in scrum_raw.get("personal_scrums", [])
     ]
-    scrum = ScrumConfig(squads=scrum_squads, personal_scrums=personal_scrums)
+    scrum = ScrumConfig(
+        squads=scrum_squads,
+        personal_scrums=personal_scrums,
+        pr_warning_excluded_members=scrum_raw.get("pr_warning_excluded_members", []),
+    )
 
     # Task alerts
     ta_raw = raw.get("task_alerts", {})

--- a/tests/test_post_scrum_message.py
+++ b/tests/test_post_scrum_message.py
@@ -1,0 +1,78 @@
+"""스크럼 PR 경고 제외 테스트"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+from scripts.post_scrum_message import format_task_line
+
+
+def _make_task(
+    title: str = "테스트 태스크",
+    deadline: str = "2026-04-07",
+    has_pr: bool = False,
+    assignee_name: str = "테스트",
+) -> dict:
+    """테스트용 태스크 생성 헬퍼"""
+    return {
+        "title": title,
+        "url": "https://notion.so/test",
+        "deadline": deadline,
+        "has_pr": has_pr,
+        "assignee_name": assignee_name,
+    }
+
+
+@patch("scripts.post_scrum_message.datetime")
+def test_format_task_line_without_pr_warning(mock_datetime):
+    """PR 경고 비활성화 시 PR 경고 텍스트 없음"""
+    mock_datetime.now.return_value = datetime(2026, 4, 7)
+    mock_datetime.fromisoformat = datetime.fromisoformat
+
+    task = _make_task(
+        title="[기획]MVP 설계", deadline="2026-04-07", assignee_name="전종현"
+    )
+    result = format_task_line(task, pr_warning_enabled=False)
+
+    assert "PR이 없으므로" not in result
+    assert "마감" in result
+
+
+@patch("scripts.post_scrum_message.datetime")
+def test_format_task_line_with_pr_warning_when_no_pr(mock_datetime):
+    """PR 경고 활성화 + 마감 임박 + PR 없으면 경고 표시"""
+    mock_datetime.now.return_value = datetime(2026, 4, 7)
+    mock_datetime.fromisoformat = datetime.fromisoformat
+
+    task = _make_task(deadline="2026-04-07", has_pr=False)
+    result = format_task_line(task, pr_warning_enabled=True)
+
+    assert "PR이 없으므로 일정 조정이 필요합니다." in result
+
+
+@patch("scripts.post_scrum_message.datetime")
+def test_format_task_line_with_pr_warning_when_has_pr(mock_datetime):
+    """PR 경고 활성화 + 마감 임박이어도 PR 있으면 경고 없음"""
+    mock_datetime.now.return_value = datetime(2026, 4, 7)
+    mock_datetime.fromisoformat = datetime.fromisoformat
+
+    task = _make_task(deadline="2026-04-07", has_pr=True)
+    result = format_task_line(task, pr_warning_enabled=True)
+
+    assert "PR이 없으므로" not in result
+
+
+def test_pr_warning_exclusion_logic():
+    """PR 경고 제외 대상 판별 로직 테스트"""
+    email_to_user_id = {
+        "planner@example.com": "U_PLANNER",
+        "dev@example.com": "U_DEV",
+    }
+    pr_warning_excluded_members = ["U_PLANNER"]
+
+    # 기획자는 제외됨
+    planner_user_id = email_to_user_id.get("planner@example.com")
+    assert planner_user_id in pr_warning_excluded_members
+
+    # 개발자는 제외되지 않음
+    dev_user_id = email_to_user_id.get("dev@example.com")
+    assert dev_user_id not in pr_warning_excluded_members


### PR DESCRIPTION
## Summary
- 스크럼 일정 알림에서 기획자/PM의 태스크에 "PR이 없으므로 일정 조정이 필요합니다" 경고가 표시되지 않도록 수정
- `config.yaml`의 `scrum.pr_warning_excluded_members`에 제외 대상 Slack user ID를 설정하면 해당 멤버의 태스크에서 PR 경고가 비활성화됨
- 현재 예진 이(코들 PM, U075PUFNGHX) 추가 완료. 전종현(해커톤 기획자)은 user ID 확인 후 추가 예정

## Changes
- `service/config.py`: `ScrumConfig`에 `pr_warning_excluded_members` 필드 추가
- `scripts/post_scrum_message.py`: `send_team_scrum`에서 제외 대상 체크 로직 추가
- `config.yaml`: `pr_warning_excluded_members` 설정 추가
- `tests/test_post_scrum_message.py`: PR 경고 제외 관련 테스트 4건 추가

## Test plan
- [x] 기존 테스트 통과 확인
- [x] PR 경고 비활성화 시 경고 텍스트 미출력 테스트
- [x] PR 경고 활성화 시 정상 출력 테스트
- [ ] 배포 후 다음 스크럼에서 예진 이 태스크에 PR 경고 미출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>