### PR TITLE
feat: 배포 로테이션 월화수 고정, 목금만 로테이션

### DIFF
--- a/app/summarize_deployment.py
+++ b/app/summarize_deployment.py
@@ -145,7 +145,10 @@ def summarize_deployment(
     # 오늘의 배포 담당자 계산
     deployer_mention = ""
     if config.deployment_rotation:
-        deployer = get_todays_deployer(config.deployment_rotation.members)
+        deployer = get_todays_deployer(
+            config.deployment_rotation.members,
+            config.deployment_rotation.fixed_days,
+        )
         if deployer:
             deployer_mention = f" (배포 담당자: <@{deployer}>)"
 

--- a/config.yaml
+++ b/config.yaml
@@ -152,8 +152,9 @@ deployment_rotation:
   channel_id: "C02VA2LLXH9"
   members:
     - "U02JLCWGETT"  # 배영빈
-    - "U07RP7U3FPU"
+    - "U07RP7U3FPU"  # 박기영
     - "U02PFUPCJNM"  # 류호선
+  fixed_days: 3  # 월화수 고정 (members 순서대로), 나머지 요일만 로테이션
 
 scheduled_jobs:
   - name: validate_customer_reports

--- a/scripts/announce_deployment_rotation.py
+++ b/scripts/announce_deployment_rotation.py
@@ -30,7 +30,7 @@ def main():
 
     today = date.today()
     year, month = today.year, today.month
-    schedule = get_weekday_schedule(year, month, rotation.members)
+    schedule = get_weekday_schedule(year, month, rotation.members, rotation.fixed_days)
 
     lines = [f"\U0001f4cb {month}월 배포 담당자 안내\n"]
     for weekday_idx in range(5):

--- a/service/config.py
+++ b/service/config.py
@@ -117,6 +117,7 @@ class DeploymentRotationConfig:
 
     channel_id: str
     members: list[str]
+    fixed_days: int = 0
 
 
 # --- 스케줄 작업 ---
@@ -248,6 +249,7 @@ def _parse_config(raw: dict) -> AppConfig:
         deployment_rotation = DeploymentRotationConfig(
             channel_id=dr_raw["channel_id"],
             members=dr_raw["members"],
+            fixed_days=dr_raw.get("fixed_days", 0),
         )
 
     # Scheduled jobs

--- a/service/deployment_rotation.py
+++ b/service/deployment_rotation.py
@@ -16,26 +16,41 @@ def _get_rotation_offset(year: int, month: int, num_members: int) -> int:
     return (year * 12 + month) % num_members
 
 
-def get_weekday_schedule(year: int, month: int, members: list[str]) -> dict[int, str]:
+def get_weekday_schedule(
+    year: int, month: int, members: list[str], fixed_days: int = 0
+) -> dict[int, str]:
     """해당 월의 요일별 배포 담당자 매핑 반환
 
     Args:
         year: 연도
         month: 월
         members: 배포 담당자 Slack user ID 목록
+        fixed_days: 고정 요일 수 (0부터 시작, members 순서대로 고정)
 
     Returns:
         dict[int, str]: 요일 인덱스(0=월..4=금) -> Slack user ID
     """
-    offset = _get_rotation_offset(year, month, len(members))
-    return {i: members[(i + offset) % len(members)] for i in range(5)}
+    schedule = {}
+    # 고정 요일: members[i]를 요일 i에 배정
+    for i in range(min(fixed_days, 5)):
+        schedule[i] = members[i % len(members)]
+
+    # 로테이션 요일
+    rotation_days = list(range(fixed_days, 5))
+    if rotation_days:
+        offset = _get_rotation_offset(year, month, len(members))
+        for idx, weekday in enumerate(rotation_days):
+            schedule[weekday] = members[(idx + offset) % len(members)]
+
+    return schedule
 
 
-def get_todays_deployer(members: list[str]) -> str | None:
+def get_todays_deployer(members: list[str], fixed_days: int = 0) -> str | None:
     """오늘의 배포 담당자를 반환. 영업일이 아니면 None.
 
     Args:
         members: 배포 담당자 Slack user ID 목록
+        fixed_days: 고정 요일 수 (0부터 시작, members 순서대로 고정)
 
     Returns:
         str | None: 오늘의 배포 담당자 Slack user ID, 영업일이 아니면 None
@@ -46,5 +61,5 @@ def get_todays_deployer(members: list[str]) -> str | None:
     weekday = today.weekday()  # 0=월..4=금
     if weekday >= 5:
         return None
-    schedule = get_weekday_schedule(today.year, today.month, members)
+    schedule = get_weekday_schedule(today.year, today.month, members, fixed_days)
     return schedule[weekday]

--- a/tests/test_deployment_rotation.py
+++ b/tests/test_deployment_rotation.py
@@ -88,3 +88,48 @@ def test_schedule_different_months():
     # 12개월 중 최소 2가지 이상의 다른 스케줄이 있어야 함
     unique = len(set(tuple(s.items()) for s in schedules))
     assert unique >= 2
+
+
+# --- fixed_days 테스트 ---
+
+
+def test_fixed_days_assigns_in_order():
+    """fixed_days=3이면 월/화/수가 members[0]/[1]/[2]에 고정 배정"""
+    schedule = get_weekday_schedule(2026, 4, MEMBERS, fixed_days=3)
+    assert schedule[0] == MEMBERS[0]  # 월 -> U_A
+    assert schedule[1] == MEMBERS[1]  # 화 -> U_B
+    assert schedule[2] == MEMBERS[2]  # 수 -> U_C
+
+
+def test_fixed_days_rotation_for_remaining():
+    """fixed_days=3이면 목/금만 로테이션으로 배정"""
+    schedule = get_weekday_schedule(2026, 4, MEMBERS, fixed_days=3)
+    # 목/금은 로테이션 오프셋에 따라 결정
+    offset = _get_rotation_offset(2026, 4, len(MEMBERS))
+    assert schedule[3] == MEMBERS[(0 + offset) % len(MEMBERS)]  # 목
+    assert schedule[4] == MEMBERS[(1 + offset) % len(MEMBERS)]  # 금
+
+
+def test_fixed_days_consistency():
+    """같은 월에서 fixed_days 스케줄은 항상 동일"""
+    s1 = get_weekday_schedule(2026, 4, MEMBERS, fixed_days=3)
+    s2 = get_weekday_schedule(2026, 4, MEMBERS, fixed_days=3)
+    assert s1 == s2
+
+
+def test_todays_deployer_with_fixed_days():
+    """fixed_days 적용 시 오늘의 배포 담당자가 올바르게 반환"""
+    # 2026-04-06은 월요일 (weekday=0), fixed_days=3이면 members[0] 고정
+    with patch("service.deployment_rotation.date") as mock_date, patch(
+        "service.deployment_rotation.is_business_day", return_value=True
+    ):
+        mock_date.today.return_value = date(2026, 4, 6)
+        result = get_todays_deployer(MEMBERS, fixed_days=3)
+        assert result == MEMBERS[0]
+
+
+def test_fixed_days_zero_is_full_rotation():
+    """fixed_days=0이면 기존 전체 로테이션과 동일"""
+    schedule_default = get_weekday_schedule(2026, 4, MEMBERS)
+    schedule_zero = get_weekday_schedule(2026, 4, MEMBERS, fixed_days=0)
+    assert schedule_default == schedule_zero


### PR DESCRIPTION
## Summary
- 배포 담당자 로테이션을 월/화/수 고정, 목/금만 로테이션으로 변경
- 월: 배영빈, 화: 박기영, 수: 류호선 (고정), 목/금: 3명 중 월별 로테이션
- `config.yaml`의 `deployment_rotation.fixed_days: 3` 설정으로 제어

## Changes
- `service/deployment_rotation.py`: `get_weekday_schedule`, `get_todays_deployer`에 `fixed_days` 파라미터 추가
- `service/config.py`: `DeploymentRotationConfig`에 `fixed_days` 필드 추가
- `config.yaml`: `fixed_days: 3` 설정 추가, 박기영 코멘트 추가
- `scripts/announce_deployment_rotation.py`: `fixed_days` 전달
- `app/summarize_deployment.py`: `fixed_days` 전달
- `tests/test_deployment_rotation.py`: fixed_days 관련 테스트 5건 추가

## Test plan
- [x] 기존 테스트 통과 (fixed_days=0 기본값으로 하위 호환)
- [x] 월/화/수가 members[0]/[1]/[2]에 고정 배정 테스트
- [x] 목/금만 월별 오프셋으로 로테이션 테스트
- [ ] 배포 후 `/announce-deployment-rotation` 명령으로 스케줄 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>