### PR TITLE
fix: explore config에서 잘못된 상태 그룹명 제거

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,7 +46,7 @@ notion_databases:
       assignee: "담당자"
       timeline: "타임라인"
     pending_statuses: []
-    in_progress_statuses: ["진행 중", "In Progress"]
+    in_progress_statuses: ["진행 중"]
 
   contents:
     data_source_id: "fecd7fca-8280-4f02-b78f-7fa720f53aa6"


### PR DESCRIPTION
## Summary
- 탐색 스쿼드 config의 `in_progress_statuses`에서 Notion 그룹명 `"In Progress"`를 제거
- Notion API `status.equals` 필터는 옵션명만 인식하며, 그룹명은 400 에러를 유발할 수 있음
- PR #82에서 `"테스트 중"`을 `"In Progress"`로 교체했으나, 이것은 그룹명(옵션명 아님)이므로 제거
- 탐색 DB의 실제 상태 옵션: `시작 전`, `진행 중`, `완료`, `중단`

## Test plan
- [ ] CI 통과 확인
- [ ] 배포 후 내일 스크럼에서 탐색 스쿼드 쓰레드 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)