### PR TITLE
fix: 공휴일 API 오류 시 스크럼 스레드 누락 방지

### DIFF
--- a/api/data_go_kr.py
+++ b/api/data_go_kr.py
@@ -23,4 +23,5 @@ def get_rest_de_info(year: int, month: int):
         "numOfRows": "100",
     }
     response = requests.get(url, params=params, timeout=10)
+    response.raise_for_status()
     return response.json()

--- a/service/holidays.py
+++ b/service/holidays.py
@@ -23,9 +23,9 @@ def get_public_holidays(year: int, month: int) -> set[str]:
     Note:
         - 근로자의 날(5/1)은 공공데이터에 없으므로 수동 추가
     """
-    data = get_rest_de_info(year, month)
     holidays = set()
     try:
+        data = get_rest_de_info(year, month)
         items = data["response"]["body"]["items"]
         if "item" in items:
             item = items["item"]
@@ -42,8 +42,7 @@ def get_public_holidays(year: int, month: int) -> set[str]:
                     date_str = f"{locdate[:4]}-{locdate[4:6]}-{locdate[6:]}"
                     holidays.add(date_str)
     except Exception as e:
-        print("[ERROR] Parsing holiday info:", e)
-        print("Response data:", data)
+        print("[ERROR] Fetching/parsing holiday info:", e)
 
     # 수동으로 특정 휴일 추가
     if month == 5:


### PR DESCRIPTION
## Summary
- `data.go.kr` 공휴일 API가 502 등 비정상 응답 시 `JSONDecodeError`가 발생하여 탐색/인프라 스크럼 스레드가 누락되는 버그 수정
- `api/data_go_kr.py`: `response.raise_for_status()` 추가로 HTTP 에러를 명확히 보고
- `service/holidays.py`: `get_rest_de_info()` 호출을 기존 try/except 블록 안으로 이동하여 API 장애 시에도 빈 공휴일 셋으로 graceful fallback

## Context
- Sentry: WORKFLOW-AUTOMATION-4N (2026-04-08)
- 4/7, 4/8 연속으로 탐색 스쿼드 및 인프라 팀 스크럼 스레드가 누락됨
- 근본 원인: `get_rest_de_info()`가 API 응답 상태코드를 체크하지 않아 비정상 응답의 `.json()` 호출에서 크래시

## Test plan
- [ ] CI 통과 확인
- [ ] 내일 스크럼 시간에 전체 스쿼드 스레드 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)