### PR TITLE
탐색 스쿼드 일일 작업 알림 누락 수정

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -42,10 +42,10 @@ notion_databases:
     data_source_id: "3141cc82-0da6-8103-913c-000ba234b439"
     properties:
       title: "작업"
-      status: "진행 상태"
+      status: "상태"
       assignee: "담당자"
       timeline: "타임라인"
-    pending_statuses: []
+    pending_statuses: ["대기"]
     in_progress_statuses: ["진행 중"]
 
   contents:
@@ -139,6 +139,10 @@ task_alerts:
           alerts:
             - alert_overdue_tasks
             - alert_pending_but_started_tasks
+            - alert_no_due_tasks
+            - alert_no_tasks
+        - handle: "탐색"
+          alerts:
             - alert_no_due_tasks
             - alert_no_tasks
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -97,12 +97,16 @@ def test_task_alert_pipelines():
         "코들",
         "해커톤",
         "ie",
+        "탐색",
     ]
     codle = product.pipeline_squads[0]
     assert "alert_overdue_tasks" in codle.alerts
     assert "alert_no_upcoming_tasks" in codle.alerts
     ie = product.pipeline_squads[2]
     assert "alert_no_upcoming_tasks" not in ie.alerts
+    explore = product.pipeline_squads[3]
+    assert "alert_no_due_tasks" in explore.alerts
+    assert "alert_overdue_tasks" not in explore.alerts
 
     contents = config.task_alerts.pipelines[1]
     assert contents.name == "콘텐츠 본부"


### PR DESCRIPTION
## Summary
- explore DB의 status 프로퍼티명을 `"진행 상태"` → `"상태"`로 수정 (노션 DB 변경사항 반영)
- explore DB의 `pending_statuses`에 `"대기"` 추가
- 제품 본부 `task_alerts` 파이프라인에 탐색 스쿼드 추가 (`alert_no_due_tasks`, `alert_no_tasks`)

## Context
탐색 스쿼드의 노션 DB 속성이 인프라팀/코들 스쿼드와 동일하게 변경되었으나, `config.yaml`에 반영되지 않아 일일 작업 알림이 누락되고 있었습니다.

`alert_overdue_tasks`, `alert_pending_but_started_tasks`는 `start_date`/`end_date` 프로퍼티가 필요하나, explore DB에는 해당 프로퍼티가 없어 제외했습니다.

## Test plan
- [ ] `python scripts/manage_tasks_daily.py --dry-run`으로 탐색 스쿼드 알림 정상 출력 확인
- [ ] 스크럼 메시지에서 탐색 스쿼드 정상 조회 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)