### PR TITLE
배포 예정 과업 알림에서 해커톤 스쿼드 제외

### DIFF
--- a/app/summarize_deployment.py
+++ b/app/summarize_deployment.py
@@ -159,6 +159,8 @@ def summarize_deployment(
     tasks = []
     db_by_task_url: dict[str, NotionDBConfig] = {}
     for ps in product_pipeline.pipeline_squads:
+        if ps.squad.handle == "해커톤":
+            continue
         db = ps.squad.notion_db
         if not db.properties.pr:
             continue


### PR DESCRIPTION
## Summary
- 매일 16:30에 전송되는 배포 예정 과업 알림(`summarize_deployment`)에서 해커톤 스쿼드의 과업을 제외합니다.
- `summarize_deployment.py`의 스쿼드 순회 루프에서 `해커톤` 핸들을 가진 스쿼드를 스킵하도록 필터 추가

## Test plan
- [ ] `/summarize-deployment` 슬랙 명령어로 해커톤 스쿼드 과업이 제외되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Notion: https://www.notion.so/33e1cc820da6813e8565d5b28c56eb22