### PR TITLE
fix: Slack 세션 TimeoutError 로그도 Sentry 필터 대상에 추가

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,6 +32,10 @@ def _before_send(event, hint):
         message = event.get("message", "")
     if "ClientConnectionResetError" in message:
         return None
+    # Slack Socket Mode 세션 타임아웃/재연결 실패 로그 필터
+    # (세션 ID가 매번 달라 이슈가 각각 생성되어 노이즈가 큼)
+    if "Failed to check the current session" in message:
+        return None
     return event
 
 


### PR DESCRIPTION
## Summary
- `slack_bolt.AsyncApp`이 소켓 모드 세션을 복구하지 못할 때 남기는 `Failed to check the current session (s_XXX) or reconnect to the server (error: TimeoutError, message: )` 로그 이벤트를 Sentry 전송에서 제외
- 세션 ID가 매번 달라 Sentry가 이슈를 개별 생성(24시간 내 22건) → 노이즈 해소
- 기존 `ClientConnectionResetError` 필터(PR #76, AHA-52)와 같은 방식의 소켓 모드 인프라 노이즈 필터 확장

## Test plan
- [ ] 로컬에서 `_before_send`를 직접 호출하여 해당 메시지 패턴이 `None`을 반환하는지 확인
- [ ] 배포 후 Sentry `workflow-automation` 프로젝트에 동일 제목 이슈가 더 이상 생성되지 않는지 24–48시간 모니터링

Refs: [AHA-89](https://www.notion.so/TimeoutError-Sentry-3441cc820da681a991baf6b51f3bc8d0)