### PR TITLE
feat: skip main protection ruleset for tmn-component-screenshot

### DIFF
--- a/scripts/github_admin/repo_rulesets_config.json
+++ b/scripts/github_admin/repo_rulesets_config.json
@@ -8,6 +8,9 @@
   "tmn-cc-settings": {
     "skip": ["ruleset.json"]
   },
+  "tmn-component-screenshot": {
+    "skip": ["ruleset.json"]
+  },
   "*-memory": {
     "skip": ["ruleset.json", "ruleset_develop.json"],
     "add": ["ruleset_main_force_push_only.json"]


### PR DESCRIPTION
## Summary
- `tmn-component-screenshot` 리포를 `repo_rulesets_config.json`의 skip 대상에 추가하여 "Main Protection By Security" 룰셋이 적용/유지되지 않도록 한다.
- 다음 `add_ruleset.py` 실행 시 이 리포에 이미 추가된 동명 룰셋이 있으면 삭제된다 (`apply_ruleset_to_repos` 의 skip 분기).

## Why
`jce-codle-react`의 `scripts/upload-screenshot.sh`는 `gh api PUT /repos/.../contents/...`로 main 브랜치에 직접 커밋하는 구조로, 컴포넌트 스크린샷 업로드 워크플로우의 핵심이다. 2026-04-22에 이 리포에 "Main Protection By Security" 룰셋이 신규 적용되면서 업로드가 HTTP 409 `Changes must be made through a pull request`로 막혔다.

스크린샷 리포는 이미지 asset 저장소에 가까워 PR 리뷰 플로우를 거칠 필요가 없으므로, `tmn-e2e-video`, `tmn-cc-settings`와 동일하게 skip 처리한다.

## Test plan
- [ ] `python scripts/github_admin/add_ruleset.py --dry-run` 로 `tmn-component-screenshot`에 대해 `기존 Main Protection By Security 삭제 예정 (config에서 제외됨)` 메시지 확인
- [ ] 머지 후 본 스크립트를 실제 실행해 룰셋 삭제 확인
- [ ] `jce-codle-react`에서 `bash scripts/upload-screenshot.sh <image>` 재시도해 업로드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)