### PR TITLE
feat: 배포 요약에서 해커톤 스쿼드 제외 해제

### DIFF
--- a/app/summarize_deployment.py
+++ b/app/summarize_deployment.py
@@ -159,8 +159,6 @@ def summarize_deployment(
     tasks = []
     db_by_task_url: dict[str, NotionDBConfig] = {}
     for ps in product_pipeline.pipeline_squads:
-        if ps.squad.handle == "해커톤":
-            continue
         db = ps.squad.notion_db
         if not db.properties.pr:
             continue


### PR DESCRIPTION
## Summary
- 해커톤 스쿼드가 운영환경을 구축했으므로, 배포 예정 과업 알림(`summarize_deployment`)에서 해커톤 스쿼드를 제외하던 필터링을 제거
- `app/summarize_deployment.py`에서 `if ps.squad.handle == "해커톤": continue` 2줄 삭제

## Test plan
- [ ] CI 통과 확인
- [ ] 배포 요약 실행 시 해커톤 스쿼드 과업이 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)