### PR TITLE
fix: 평일 공휴일에 배포 예정 과업 메시지 발송하지 않도록 수정

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -235,7 +235,7 @@ scheduled_jobs:
       hour: 16
       minute: 30
       day_of_week: mon-fri
-    business_day_only: false
+    business_day_only: true
 
   - name: schedule_scrum_mention
     module: scripts.schedule_scrum_mention


### PR DESCRIPTION
## Summary
- `summarize_deployment`의 `business_day_only`를 `true`로 변경
- 공휴일에는 배포를 하지 않으므로, 배포 예정 과업 메시지 자체를 발송하지 않도록 함
- 기존 접근(배포 담당자 태그만 수정)에서 피드백 반영하여 방향 변경

## Context
5월 1일(근로자의 날) 등 평일 공휴일에 `summarize_deployment`이 `business_day_only: false`로 설정되어 있어 메시지가 발송되었으나, 공휴일에는 배포 자체를 하지 않으므로 메시지도 발송하지 않는 것이 적절함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)