### PR TITLE
chore: tmn-n8n 레포 ruleset 설정 추가

### DIFF
--- a/scripts/github_admin/repo_rulesets_config.json
+++ b/scripts/github_admin/repo_rulesets_config.json
@@ -28,5 +28,9 @@
   },
   "enk-plan-md": {
     "skip": ["ruleset.json"]
+  },
+  "tmn-n8n": {
+    "skip": ["ruleset.json", "ruleset_develop.json"],
+    "add": ["ruleset_main_force_push_only.json"]
   }
 }


### PR DESCRIPTION
## Summary
- tmn-n8n 레포에 `ruleset_main_force_push_only.json` 적용
- main branch direct push 허용, force push/삭제만 차단

## Context
- tmn-n8n은 인프라 설정 레포로 PR 없이 main에 직접 push하는 워크플로우
- 기존 기본 ruleset이 PR 필수로 설정되어 push가 차단됨

## Test plan
- [ ] `python scripts/github_admin/add_ruleset.py` 실행하여 ruleset 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)