### PR TITLE
fix: Slack 이벤트 중복 처리 방지 (event_id 기반 dedup)

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ import sentry_sdk
 from aiohttp import ClientConnectionResetError
 from dotenv import load_dotenv
 from slack_bolt.async_app import AsyncApp, AsyncAssistant
-from slack_bolt.adapter.socket_mode.aiohttp import AsyncSocketModeHandler
+from app.socket_mode_handler import AsyncImmediateAckSocketModeHandler
 
 from app.general import register_general_handlers
 from app.contents import register_contents_handlers
@@ -65,19 +65,19 @@ async def main():
     # Assistant 등록
     app.use(assistant)
 
-    # Async Socket Mode Handler
-    handler = AsyncSocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])
+    # Async Socket Mode Handler (즉시 ack로 이벤트 재전송 방지)
+    handler = AsyncImmediateAckSocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])
     bot_coroutine = handler.start_async()
 
-    contents_coroutine = AsyncSocketModeHandler(
+    contents_coroutine = AsyncImmediateAckSocketModeHandler(
         app_contents, os.environ["SLACK_APP_TOKEN_CONTENTS"]
     ).start_async()
 
-    data_coroutine = AsyncSocketModeHandler(
+    data_coroutine = AsyncImmediateAckSocketModeHandler(
         app_data, os.environ["SLACK_APP_TOKEN_DATA"]
     ).start_async()
 
-    justin_coroutine = AsyncSocketModeHandler(
+    justin_coroutine = AsyncImmediateAckSocketModeHandler(
         app_justin, os.environ["SLACK_APP_TOKEN_JUSTIN"]
     ).start_async()
 

--- a/app/contents.py
+++ b/app/contents.py
@@ -2,6 +2,7 @@
 콘텐츠 비서 봇 전용 로직
 """
 
+from .event_dedup import is_duplicate_event
 from .common import (
     answer,
     search_tool,
@@ -31,6 +32,9 @@ def register_contents_handlers(app_contents):
         """
         슬랙에서 콘텐츠 비서를 멘션하여 대화를 시작하면 호출되는 이벤트
         """
+        if is_duplicate_event(body):
+            return
+
         event = body.get("event")
 
         if event is None:

--- a/app/data_bot.py
+++ b/app/data_bot.py
@@ -3,11 +3,13 @@
 """
 
 from datetime import datetime
+
 from langchain_core.messages import BaseMessage, SystemMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
 from .common import KST, slack_users_list
+from .event_dedup import is_duplicate_event
 from .tool_status_handler import ToolStatusHandler
 from .tools.athena_tools import get_execute_athena_query_tool
 from .tools.chart_tools import get_execute_python_with_chart_tool
@@ -28,6 +30,9 @@ def register_data_handlers(app_data):
         """
         슬랙에서 데이터 봇을 멘션하여 데이터 분석을 시작하면 호출되는 이벤트
         """
+        if is_duplicate_event(body):
+            return
+
         event = body.get("event")
 
         if event is None:

--- a/app/event_dedup.py
+++ b/app/event_dedup.py
@@ -1,0 +1,32 @@
+"""
+Slack 이벤트 중복 처리 방지 모듈
+
+Socket Mode에서 이벤트 핸들러 완료 후에야 envelope ack가 전송되므로,
+LLM 호출 등 오래 걸리는 핸들러는 Slack이 이벤트를 재전송하게 됩니다.
+이 모듈은 event_id 기반 TTL 캐시로 중복 이벤트를 필터링합니다.
+"""
+
+from cachetools import TTLCache
+
+# 5분 TTL, 최대 1000개 이벤트 추적
+_processed_events: TTLCache = TTLCache(maxsize=1000, ttl=300)
+
+
+def is_duplicate_event(body: dict) -> bool:
+    """이미 처리 중이거나 처리된 이벤트인지 확인합니다.
+
+    Args:
+        body: Slack 이벤트 body (event_id 포함)
+
+    Returns:
+        True이면 중복 이벤트이므로 스킵해야 합니다.
+    """
+    event_id = body.get("event_id")
+    if not event_id:
+        return False
+
+    if event_id in _processed_events:
+        return True
+
+    _processed_events[event_id] = True
+    return False

--- a/app/general.py
+++ b/app/general.py
@@ -12,6 +12,7 @@ from slack_bolt.async_app import AsyncBoltContext, AsyncSetStatus
 from slack_sdk.web.async_client import AsyncWebClient
 
 from . import analyze_oom, route_bug, route_dev_env_infra_bug
+from .event_dedup import is_duplicate_event
 from .common import (
     KST,
     answer,
@@ -78,6 +79,9 @@ def register_general_handlers(app, assistant):
         """
         슬랙에서 로봇을 멘션하여 대화를 시작하면 호출되는 이벤트
         """
+        if is_duplicate_event(body):
+            return
+
         event = body.get("event")
 
         if event is None:
@@ -146,6 +150,9 @@ def register_general_handlers(app, assistant):
         버그 신고 채널에 올라오는 메시지를 LLM으로 분석하여
         Notion에 버그 작업을 생성하고, 시급한 경우 담당 그룹을 태그합니다.
         """
+        if is_duplicate_event(body):
+            return
+
         print("Received message event:", body)
 
         event = body.get("event", {})

--- a/app/justin.py
+++ b/app/justin.py
@@ -21,6 +21,7 @@ import anthropic
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import SystemMessage, HumanMessage
 from .common import slack_users_list, notion_page_to_markdown
+from .event_dedup import is_duplicate_event
 from .tool_status_handler import ToolStatusHandler
 
 KST = ZoneInfo("Asia/Seoul")
@@ -166,6 +167,9 @@ def register_justin_handlers(app):
         - Notion 링크가 있으면 → 미팅 보고서 피드백
         - PDF 첨부파일이 있으면 → 제안서 피드백 (네이티브 PDF)
         """
+        if is_duplicate_event(body):
+            return
+
         event = body.get("event")
         if event is None:
             return

--- a/app/socket_mode_handler.py
+++ b/app/socket_mode_handler.py
@@ -1,0 +1,54 @@
+"""
+즉시 envelope ack를 전송하는 Socket Mode 핸들러
+
+기본 AsyncSocketModeHandler는 이벤트 핸들러 완료 후 ack를 전송하므로,
+LLM 호출 등 오래 걸리는 핸들러에서 Slack이 ~20초 후 이벤트를 재전송합니다.
+events_api 타입만 ack를 먼저 전송하고 처리를 백그라운드로 위임합니다.
+"""
+
+import asyncio
+import logging
+from time import time
+
+from slack_bolt.adapter.socket_mode.aiohttp import AsyncSocketModeHandler
+from slack_bolt.adapter.socket_mode.async_internals import (
+    run_async_bolt_app,
+    send_async_response,
+)
+from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.socket_mode.response import SocketModeResponse
+
+logger = logging.getLogger(__name__)
+
+# create_task 참조를 유지하여 GC 방지
+_background_tasks: set[asyncio.Task] = set()
+
+
+class AsyncImmediateAckSocketModeHandler(AsyncSocketModeHandler):
+    """events_api에 대해 envelope ack를 즉시 전송하는 Socket Mode 핸들러."""
+
+    async def handle(
+        self, client: AsyncBaseSocketModeClient, req: SocketModeRequest
+    ) -> None:
+        if req.type == "events_api":
+            # events_api는 ack 페이로드가 불필요하므로 즉시 ack 전송
+            await client.send_socket_mode_response(
+                SocketModeResponse(envelope_id=req.envelope_id)
+            )
+            # 리스너 루프를 블로킹하지 않도록 백그라운드 태스크로 실행
+            task = asyncio.create_task(self._dispatch_event(req))
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
+        else:
+            # slash_commands, interactive 등은 ack에 응답 페이로드가 필요하므로
+            # 기존 동작 유지 (핸들러 완료 후 ack)
+            start = time()
+            bolt_resp = await run_async_bolt_app(self.app, req)
+            await send_async_response(client, req, bolt_resp, start)
+
+    async def _dispatch_event(self, req: SocketModeRequest) -> None:
+        try:
+            await run_async_bolt_app(self.app, req)
+        except Exception:
+            logger.exception("Failed to handle Socket Mode event")

--- a/tests/test_event_dedup.py
+++ b/tests/test_event_dedup.py
@@ -1,0 +1,45 @@
+"""
+이벤트 중복 처리 방지 모듈 테스트
+"""
+
+from app.event_dedup import is_duplicate_event, _processed_events
+
+
+def setup_function():
+    """각 테스트 전에 캐시를 초기화합니다."""
+    _processed_events.clear()
+
+
+def test_first_event_is_not_duplicate():
+    """최초 이벤트는 중복이 아닙니다."""
+    body = {"event_id": "Ev001", "event": {"type": "app_mention"}}
+    assert is_duplicate_event(body) is False
+
+
+def test_same_event_id_is_duplicate():
+    """동일한 event_id로 두 번째 호출하면 중복입니다."""
+    body = {"event_id": "Ev001", "event": {"type": "app_mention"}}
+    assert is_duplicate_event(body) is False
+    assert is_duplicate_event(body) is True
+
+
+def test_different_event_ids_are_not_duplicates():
+    """서로 다른 event_id는 중복이 아닙니다."""
+    body1 = {"event_id": "Ev001", "event": {"type": "app_mention"}}
+    body2 = {"event_id": "Ev002", "event": {"type": "app_mention"}}
+    assert is_duplicate_event(body1) is False
+    assert is_duplicate_event(body2) is False
+
+
+def test_missing_event_id_is_not_duplicate():
+    """event_id가 없는 body는 중복으로 처리하지 않습니다."""
+    body = {"event": {"type": "app_mention"}}
+    assert is_duplicate_event(body) is False
+    assert is_duplicate_event(body) is False
+
+
+def test_triple_retry_only_first_passes():
+    """Socket Mode 재시도 시나리오: 동일 이벤트 3번 전달 시 첫 번째만 통과합니다."""
+    body = {"event_id": "Ev_retry_test", "event": {"type": "app_mention"}}
+    results = [is_duplicate_event(body) for _ in range(3)]
+    assert results == [False, True, True]

--- a/tests/test_socket_mode_handler.py
+++ b/tests/test_socket_mode_handler.py
@@ -1,0 +1,176 @@
+"""
+AsyncImmediateAckSocketModeHandler 테스트
+
+events_api에 대해 즉시 ack를 전송하고,
+그 외 타입은 기존 동작을 유지하는지 검증합니다.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.socket_mode_handler import (
+    AsyncImmediateAckSocketModeHandler,
+    _background_tasks,
+)
+
+
+def _make_request(req_type: str = "events_api", envelope_id: str = "env-123"):
+    req = MagicMock()
+    req.type = req_type
+    req.envelope_id = envelope_id
+    req.payload = {"event": {"type": "app_mention"}}
+    return req
+
+
+@pytest.fixture
+def mock_client():
+    client = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def handler():
+    app = MagicMock()
+    h = AsyncImmediateAckSocketModeHandler.__new__(
+        AsyncImmediateAckSocketModeHandler
+    )
+    h.app = app
+    return h
+
+
+@pytest.mark.asyncio
+async def test_events_api_acks_immediately(handler, mock_client):
+    """events_api 요청은 핸들러 실행 전에 즉시 ack를 전송합니다."""
+    req = _make_request("events_api")
+    ack_sent = asyncio.Event()
+    dispatch_started = asyncio.Event()
+    dispatch_can_finish = asyncio.Event()
+
+    original_send = mock_client.send_socket_mode_response
+
+    async def track_ack(response):
+        ack_sent.set()
+        return await original_send(response)
+
+    mock_client.send_socket_mode_response = AsyncMock(side_effect=track_ack)
+
+    async def slow_dispatch(app, r):
+        dispatch_started.set()
+        await dispatch_can_finish.wait()
+        return MagicMock(status=200, body="", headers={})
+
+    with patch(
+        "app.socket_mode_handler.run_async_bolt_app", side_effect=slow_dispatch
+    ):
+        await handler.handle(mock_client, req)
+
+        # handle()이 반환된 시점에서 이미 ack가 전송되어야 함
+        assert ack_sent.is_set(), "ack should be sent before handle() returns"
+
+        # 백그라운드 태스크가 실행 중인지 확인
+        await asyncio.sleep(0.01)
+        assert dispatch_started.is_set(), "dispatch should have started in background"
+
+        # 백그라운드 태스크 완료 허용
+        dispatch_can_finish.set()
+        await asyncio.sleep(0.01)
+
+    mock_client.send_socket_mode_response.assert_called_once()
+    response = mock_client.send_socket_mode_response.call_args[0][0]
+    assert response.envelope_id == "env-123"
+
+
+@pytest.mark.asyncio
+async def test_slash_commands_use_normal_flow(handler, mock_client):
+    """slash_commands는 기존 동작을 유지합니다 (핸들러 완료 후 ack)."""
+    req = _make_request("slash_commands")
+
+    bolt_resp = MagicMock(status=200, body="", headers={})
+
+    with patch(
+        "app.socket_mode_handler.run_async_bolt_app",
+        new_callable=AsyncMock,
+        return_value=bolt_resp,
+    ), patch(
+        "app.socket_mode_handler.send_async_response",
+        new_callable=AsyncMock,
+    ) as mock_send:
+        await handler.handle(mock_client, req)
+
+    mock_send.assert_called_once()
+    # send_async_response가 client, req, bolt_resp, start_time으로 호출됨
+    call_args = mock_send.call_args[0]
+    assert call_args[0] is mock_client
+    assert call_args[1] is req
+    assert call_args[2] is bolt_resp
+
+
+@pytest.mark.asyncio
+async def test_interactive_uses_normal_flow(handler, mock_client):
+    """interactive 요청도 기존 동작을 유지합니다."""
+    req = _make_request("interactive")
+
+    bolt_resp = MagicMock(status=200, body='{"text": "ok"}', headers={"content-type": ["application/json"]})
+
+    with patch(
+        "app.socket_mode_handler.run_async_bolt_app",
+        new_callable=AsyncMock,
+        return_value=bolt_resp,
+    ), patch(
+        "app.socket_mode_handler.send_async_response",
+        new_callable=AsyncMock,
+    ) as mock_send:
+        await handler.handle(mock_client, req)
+
+    mock_send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_events_api_dispatch_error_is_logged(handler, mock_client):
+    """events_api 처리 중 에러가 발생해도 ack는 이미 전송되고, 에러는 로깅됩니다."""
+    req = _make_request("events_api")
+
+    async def failing_dispatch(app, r):
+        raise RuntimeError("LLM call failed")
+
+    with patch(
+        "app.socket_mode_handler.run_async_bolt_app", side_effect=failing_dispatch
+    ), patch("app.socket_mode_handler.logger") as mock_logger:
+        await handler.handle(mock_client, req)
+        # 백그라운드 태스크 완료 대기
+        await asyncio.sleep(0.05)
+
+    # ack는 전송됨
+    mock_client.send_socket_mode_response.assert_called_once()
+    # 에러가 로깅됨
+    mock_logger.exception.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_background_tasks_tracked(handler, mock_client):
+    """백그라운드 태스크가 _background_tasks set에 추가되고 완료 후 제거됩니다."""
+    req = _make_request("events_api")
+    initial_count = len(_background_tasks)
+
+    finish_event = asyncio.Event()
+
+    async def slow_dispatch(app, r):
+        await finish_event.wait()
+        return MagicMock(status=200, body="", headers={})
+
+    with patch(
+        "app.socket_mode_handler.run_async_bolt_app", side_effect=slow_dispatch
+    ):
+        await handler.handle(mock_client, req)
+        await asyncio.sleep(0.01)
+
+        # 태스크가 실행 중이면 set에 있어야 함
+        assert len(_background_tasks) > initial_count
+
+        finish_event.set()
+        await asyncio.sleep(0.05)
+
+    # 완료 후 제거됨
+    assert len(_background_tasks) == initial_count

--- a/tests/test_socket_mode_handler.py
+++ b/tests/test_socket_mode_handler.py
@@ -33,9 +33,7 @@ def mock_client():
 @pytest.fixture
 def handler():
     app = MagicMock()
-    h = AsyncImmediateAckSocketModeHandler.__new__(
-        AsyncImmediateAckSocketModeHandler
-    )
+    h = AsyncImmediateAckSocketModeHandler.__new__(AsyncImmediateAckSocketModeHandler)
     h.app = app
     return h
 
@@ -61,9 +59,7 @@ async def test_events_api_acks_immediately(handler, mock_client):
         await dispatch_can_finish.wait()
         return MagicMock(status=200, body="", headers={})
 
-    with patch(
-        "app.socket_mode_handler.run_async_bolt_app", side_effect=slow_dispatch
-    ):
+    with patch("app.socket_mode_handler.run_async_bolt_app", side_effect=slow_dispatch):
         await handler.handle(mock_client, req)
 
         # handle()이 반환된 시점에서 이미 ack가 전송되어야 함
@@ -112,7 +108,11 @@ async def test_interactive_uses_normal_flow(handler, mock_client):
     """interactive 요청도 기존 동작을 유지합니다."""
     req = _make_request("interactive")
 
-    bolt_resp = MagicMock(status=200, body='{"text": "ok"}', headers={"content-type": ["application/json"]})
+    bolt_resp = MagicMock(
+        status=200,
+        body='{"text": "ok"}',
+        headers={"content-type": ["application/json"]},
+    )
 
     with patch(
         "app.socket_mode_handler.run_async_bolt_app",
@@ -160,9 +160,7 @@ async def test_background_tasks_tracked(handler, mock_client):
         await finish_event.wait()
         return MagicMock(status=200, body="", headers={})
 
-    with patch(
-        "app.socket_mode_handler.run_async_bolt_app", side_effect=slow_dispatch
-    ):
+    with patch("app.socket_mode_handler.run_async_bolt_app", side_effect=slow_dispatch):
         await handler.handle(mock_client, req)
         await asyncio.sleep(0.01)
 


### PR DESCRIPTION
## Summary

- Socket Mode에서 LLM 호출 등 오래 걸리는 이벤트 핸들러로 인해 envelope ack가 지연되어, Slack이 동일 이벤트를 2~3회 재전송하는 문제를 수정합니다
- **근본 수정**: `AsyncImmediateAckSocketModeHandler`로 `events_api` envelope ack를 즉시 전송하여 Slack 재전송 자체를 방지
- **방어적 수정**: `event_id` 기반 TTL 캐시로 중복 이벤트를 핸들러 진입 시점에서 필터링 (네트워크 불안정 등 대비)

## 근본 원인

Slack Bolt Socket Mode에서는 `AsyncSocketModeHandler.handle()`이 이벤트 핸들러 완료 후에야 envelope ack를 전송합니다. LLM agent 호출이 30초 이상 소요되면 Slack이 ~20초 후 이벤트를 재전송하여 동일 요청이 여러 번 처리됩니다.

실제 사례: 단일 "과업 생성" 요청이 3회 처리되어 Notion에 3개의 중복 작업이 생성됨

## 변경 내용

### 즉시 ack (근본 수정)
- **`app/socket_mode_handler.py`** (신규): `AsyncImmediateAckSocketModeHandler` — `events_api` 요청만 즉시 ack 전송 후 백그라운드에서 핸들러 실행. `slash_commands`/`interactive`는 ack에 응답 페이로드가 필요하므로 기존 동작 유지.
- **`app.py`**: 모든 봇의 Socket Mode 핸들러를 `AsyncImmediateAckSocketModeHandler`로 교체

### event_id dedup (defense-in-depth)
- **`app/event_dedup.py`** (신규): `is_duplicate_event()` — `event_id` 기반 TTL 캐시(5분, 최대 1000개)로 중복 판별
- **`app/general.py`**: `app_mention`, `message` 핸들러에 dedup 체크 추가
- **`app/contents.py`**: `app_mention_contents` 핸들러에 dedup 체크 추가
- **`app/data_bot.py`**: `app_mention_data` 핸들러에 dedup 체크 추가
- **`app/justin.py`**: `justin_app_mention` 핸들러에 dedup 체크 추가

## Test plan

- [x] `tests/test_event_dedup.py` — 5개 단위 테스트 (최초 이벤트 통과, 동일 ID 중복 차단, 다른 ID 독립 처리, event_id 없는 경우, 3회 재시도 시나리오)
- [x] `tests/test_socket_mode_handler.py` — 5개 단위 테스트 (events_api 즉시 ack, slash_commands/interactive 기존 동작, 에러 로깅, 백그라운드 태스크 GC 방지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)