### PR TITLE
66r repo ruleset 예외처리

### DIFF
--- a/scripts/github_admin/repo_rulesets_config.json
+++ b/scripts/github_admin/repo_rulesets_config.json
@@ -49,7 +49,7 @@
     "skip": ["ruleset.json", "ruleset_develop.json"],
     "add": ["ruleset_main_force_push_only.json"]
   },
-  "66r": {
+  "66r-app-next": {
     "skip": ["ruleset.json", "ruleset_develop.json"],
     "add": ["ruleset_main_force_push_only.json"]
   }

--- a/scripts/github_admin/repo_rulesets_config.json
+++ b/scripts/github_admin/repo_rulesets_config.json
@@ -49,7 +49,7 @@
     "skip": ["ruleset.json", "ruleset_develop.json"],
     "add": ["ruleset_main_force_push_only.json"]
   },
-  "66r-app-next": {
+  "66r-*": {
     "skip": ["ruleset.json", "ruleset_develop.json"],
     "add": ["ruleset_main_force_push_only.json"]
   }

--- a/scripts/github_admin/repo_rulesets_config.json
+++ b/scripts/github_admin/repo_rulesets_config.json
@@ -48,5 +48,9 @@
   "tmn-n8n": {
     "skip": ["ruleset.json", "ruleset_develop.json"],
     "add": ["ruleset_main_force_push_only.json"]
+  },
+  "66r": {
+    "skip": ["ruleset.json", "ruleset_develop.json"],
+    "add": ["ruleset_main_force_push_only.json"]
   }
 }


### PR DESCRIPTION
## Summary
- 66r repo에 대해 기본 ruleset(PR 리뷰 필수 + develop 보호)을 제외하고, main 브랜치 삭제 방지 및 force push 금지만 적용하도록 예외 설정 추가
- `ruleset_main_force_push_only.json` 적용 (docgen, tmn-n8n 등과 동일한 패턴)

## Test plan
- [ ] `--dry-run`으로 66r에 올바른 ruleset이 적용되는지 확인
- [ ] 스크립트 실행 후 66r repo의 ruleset이 main 보호 + force push 금지만 남아있는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)