### PR TITLE
feat: 스크럼 껍데기 메시지를 9시로 분리, 16시는 태스크 요약 답글만

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -219,6 +219,15 @@ scheduled_jobs:
       day_of_week: mon
     business_day_only: false
 
+  - name: post_scrum_intro
+    module: scripts.post_scrum_intro
+    function: main
+    cron:
+      hour: 9
+      minute: 0
+      day_of_week: mon-fri
+    business_day_only: true
+
   - name: post_scrum_message
     module: scripts.post_scrum_message
     function: main

--- a/scripts/post_scrum_intro.py
+++ b/scripts/post_scrum_intro.py
@@ -1,0 +1,145 @@
+"""
+매일 09:00에 스크럼 안내 + 팀/개인 스크럼 메인(껍데기) 메시지를 발송하는 스크립트
+
+태스크 요약 답글은 16:00 post_scrum_message가 같은 스레드에 추가하고,
+작성 멘션은 16:30 schedule_scrum_mention이 같은 스레드에 추가한다.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import argparse
+import os
+
+import sentry_sdk
+from dotenv import load_dotenv
+from slack_sdk import WebClient
+
+from service.config import PersonalScrum, ScrumSquadConfig, load_config
+
+load_dotenv()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="스크럼 안내/껍데기 메시지 발송 스크립트"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="메시지를 Slack에 전송하지 않고 콘솔에만 출력합니다.",
+    )
+    args = parser.parse_args()
+
+    config = load_config()
+    slack_client = WebClient(token=os.environ.get("SLACK_BOT_TOKEN"))
+
+    if args.dry_run:
+        print("=== DRY RUN MODE ===")
+
+    scrum = config.scrum
+    squad_channel_ids = list(dict.fromkeys(s.channel_id for s in scrum.squads))
+
+    for channel_id in squad_channel_ids:
+        send_intro_message(slack_client, channel_id, squad_channel_ids, args.dry_run)
+
+    for squad in scrum.squads:
+        try:
+            send_team_scrum_shell(slack_client, squad, args.dry_run)
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            print(f"Error in send_team_scrum_shell for {squad.squad.display_name}: {e}")
+
+    for personal in scrum.personal_scrums:
+        try:
+            send_personal_scrum(slack_client, personal, args.dry_run)
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            print(f"Error in send_personal_scrum for {personal.name}: {e}")
+
+    if args.dry_run:
+        print("\n=== DRY RUN COMPLETED ===")
+
+
+def send_intro_message(
+    slack_client: WebClient,
+    channel_id: str,
+    all_channel_ids: list[str],
+    dry_run: bool = False,
+):
+    """채널에 스크럼 안내 메시지(메인 + 스레드 상세) 발송"""
+    intro_text = (
+        "좋은 아침입니다. 오늘 업무도 즐겁게 시작해서 마무리 잘 해봐요. "
+        "스크럼은 4:40까지 작성 부탁드립니다!"
+    )
+
+    other_channels = " ".join(
+        f"<#{cid}>" for cid in all_channel_ids if cid != channel_id
+    )
+
+    detail_text = f"""스크럼의 목적은 팀내의 진행상황을 확인하고, 장애를 파악하는 것입니다.
+팀원이 스크럼 중 장애를 보고하면 각 마스터(김예원 엄은상 이창환)는
+장애를 최소화 하기 위해 스크럼 후 다른 팀의 협조로 연계해주시면 되겠습니다.
+다른 팀 스크럼이 궁금하시면 본인 팀의 스크럼이 끝나고 서면으로 남겨진 내용을 자유롭게 확인하시면 됩니다.
+{other_channels}
+다른 팀의 지원이 필요하시면 본인 팀 스크럼 때, 마스터를 통해 지원을 요청 주시면 됩니다.
+(사실 스크럼이 아니더라도 업무 중 자유롭게 요청 주셔도 됩니다.)
+---------------------------------------------------------------------------
+오늘 한 일:
+- XXX 운영 진행
+내일 할 일:
+- YYY 건에 대한 대응
+오늘의 이슈:
+- ZZZ 문제 발생, 해결 방안 모색 중
+- AAA 이슈로 B팀과 협업 요청"""
+
+    if dry_run:
+        print(f"\n[안내 메시지] 채널: {channel_id}")
+        print(intro_text)
+        print(f"  └─ 스레드: {detail_text[:100]}...")
+        return
+
+    response = slack_client.chat_postMessage(channel=channel_id, text=intro_text)
+    slack_client.chat_postMessage(
+        channel=channel_id,
+        thread_ts=response["ts"],
+        text=detail_text,
+    )
+
+
+def send_team_scrum_shell(
+    slack_client: WebClient,
+    squad: ScrumSquadConfig,
+    dry_run: bool = False,
+):
+    """팀 스크럼 메인 메시지(껍데기) 발송. 16시 태스크 요약 답글이 이 스레드에 달림."""
+    text = squad.squad.display_name
+
+    if dry_run:
+        print(f"\n[{squad.squad.display_name}] 채널: {squad.channel_id}")
+        print(text)
+        return
+
+    slack_client.chat_postMessage(channel=squad.channel_id, text=text)
+
+
+def send_personal_scrum(
+    slack_client: WebClient,
+    personal: PersonalScrum,
+    dry_run: bool = False,
+):
+    """개인 스크럼 메인 메시지 발송"""
+    text = personal.name
+
+    if dry_run:
+        print(f"\n[{personal.name}] 채널: {personal.channel_id}")
+        print(text)
+        return
+
+    slack_client.chat_postMessage(channel=personal.channel_id, text=text)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/post_scrum_message.py
+++ b/scripts/post_scrum_message.py
@@ -1,5 +1,5 @@
 """
-매일 16:00에 스크럼 메시지를 Slack 채널에 발송하는 스크립트
+매일 16:00에 9시 스크럼 스레드에 진행 중인 Notion 태스크 요약을 답글로 발송하는 스크립트
 """
 
 import sys
@@ -20,11 +20,10 @@ from slack_sdk import WebClient
 from service.business_days import count_business_days
 from service.config import (
     NotionDBConfig,
-    PersonalScrum,
     ScrumSquadConfig,
     load_config,
 )
-from service.slack import get_email_to_user_id
+from service.slack import find_thread_ts_by_text, get_email_to_user_id
 
 # 환경 변수 로드
 load_dotenv()
@@ -32,7 +31,7 @@ load_dotenv()
 
 def main():
     """메인 함수"""
-    parser = argparse.ArgumentParser(description="스크럼 메시지 발송 스크립트")
+    parser = argparse.ArgumentParser(description="스크럼 태스크 요약 답글 스크립트")
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -55,17 +54,10 @@ def main():
 
     scrum = config.scrum
 
-    # 스쿼드 채널 목록 (인트로 메시지에서 다른 채널 안내용)
-    squad_channel_ids = list(dict.fromkeys(s.channel_id for s in scrum.squads))
-
-    # 1. 각 스쿼드 채널에 안내 메시지 발송
-    for channel_id in squad_channel_ids:
-        send_intro_message(slack_client, channel_id, squad_channel_ids, args.dry_run)
-
-    # 2. 스쿼드별 스크럼
+    # 스쿼드별 태스크 요약 답글
     for squad in scrum.squads:
         try:
-            send_team_scrum(
+            reply_team_scrum_tasks(
                 notion,
                 slack_client,
                 email_to_user_id,
@@ -75,79 +67,15 @@ def main():
             )
         except Exception as e:
             sentry_sdk.capture_exception(e)
-            print(f"Error in send_team_scrum for {squad.squad.display_name}: {e}")
-
-    # 3. 개인 스크럼
-    for personal in scrum.personal_scrums:
-        try:
-            send_personal_scrum(slack_client, personal, args.dry_run)
-        except Exception as e:
-            sentry_sdk.capture_exception(e)
-            print(f"Error in send_personal_scrum for {personal.name}: {e}")
+            print(
+                f"Error in reply_team_scrum_tasks for {squad.squad.display_name}: {e}"
+            )
 
     if args.dry_run:
         print("\n=== DRY RUN COMPLETED ===")
 
 
-def send_intro_message(
-    slack_client: WebClient,
-    channel_id: str,
-    all_channel_ids: list[str],
-    dry_run: bool = False,
-):
-    """
-    안내 메시지 발송
-
-    Args:
-        slack_client: Slack WebClient
-        channel_id: 발송 대상 채널 ID
-        all_channel_ids: 전체 스쿼드 채널 ID 목록 (다른 채널 안내용)
-        dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
-    """
-    intro_text = "오늘 스크럼을 시작합니다. 4:40까지 작성 부탁드립니다!"
-
-    # 다른 스쿼드 채널 링크 생성
-    other_channels = " ".join(
-        f"<#{cid}>" for cid in all_channel_ids if cid != channel_id
-    )
-
-    detail_text = f"""스크럼의 목적은 팀내의 진행상황을 확인하고, 장애를 파악하는 것입니다.
-팀원이 스크럼 중 장애를 보고하면 각 마스터(김예원 엄은상 이창환)는
-장애를 최소화 하기 위해 스크럼 후 다른 팀의 협조로 연계해주시면 되겠습니다.
-다른 팀 스크럼이 궁금하시면 본인 팀의 스크럼이 끝나고 서면으로 남겨진 내용을 자유롭게 확인하시면 됩니다.
-{other_channels}
-다른 팀의 지원이 필요하시면 본인 팀 스크럼 때, 마스터를 통해 지원을 요청 주시면 됩니다.
-(사실 스크럼이 아니더라도 업무 중 자유롭게 요청 주셔도 됩니다.)
----------------------------------------------------------------------------
-오늘 한 일:
-- XXX 운영 진행
-내일 할 일:
-- YYY 건에 대한 대응
-오늘의 이슈:
-- ZZZ 문제 발생, 해결 방안 모색 중
-- AAA 이슈로 B팀과 협업 요청"""
-
-    if dry_run:
-        print(f"\n[안내 메시지] 채널: {channel_id}")
-        print(intro_text)
-        print(f"  └─ 스레드: {detail_text[:100]}...")
-    else:
-        # 메인 메시지 발송
-        response = slack_client.chat_postMessage(
-            channel=channel_id,
-            text=intro_text,
-        )
-
-        # 스레드에 상세 안내 추가
-        thread_ts = response["ts"]
-        slack_client.chat_postMessage(
-            channel=channel_id,
-            thread_ts=thread_ts,
-            text=detail_text,
-        )
-
-
-def send_team_scrum(
+def reply_team_scrum_tasks(
     notion: NotionClient,
     slack_client: WebClient,
     email_to_user_id: dict[str, str],
@@ -156,7 +84,7 @@ def send_team_scrum(
     dry_run: bool = False,
 ):
     """
-    팀별 스크럼 메시지 발송 (Notion에서 진행 중인 태스크 조회)
+    팀 스크럼 스레드에 진행 중인 Notion 태스크 요약을 답글로 발송
 
     Args:
         notion: Notion Client
@@ -166,31 +94,21 @@ def send_team_scrum(
         pr_warning_excluded_members: PR 경고 제외 대상 Slack User ID 목록
         dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
     """
-    # 메인 메시지
-    text = f"{squad.squad.display_name}"
-
-    if dry_run:
-        print(f"\n[{squad.squad.display_name}] 채널: {squad.channel_id}")
-        print(text)
-
     # 팀 멤버의 진행 중인 태스크 조회
     team_members = get_team_members(slack_client, squad.squad.slack_usergroup_id)
     team_emails = [
         email for email, user_id in email_to_user_id.items() if user_id in team_members
     ]
 
-    # Notion에서 진행 중인 태스크 조회
     in_progress_tasks = get_in_progress_tasks(
         notion, team_emails, squad.squad.notion_db
     )
 
     # 이메일별로 태스크 그룹화
-    email_to_tasks = {}
+    email_to_tasks: dict[str, list[dict[str, Any]]] = {}
     for task in in_progress_tasks:
         email = task["email"]
-        if email not in email_to_tasks:
-            email_to_tasks[email] = []
-        email_to_tasks[email].append(task)
+        email_to_tasks.setdefault(email, []).append(task)
 
     # 인원별로 메시지 포맷팅
     thread_messages = []
@@ -198,21 +116,16 @@ def send_team_scrum(
         if not tasks:
             continue
 
-        # 담당자 이름 (첫 번째 태스크에서 가져옴)
         assignee_name = tasks[0]["assignee_name"]
-
-        # 기획자/PM은 PR 경고에서 제외
         user_id = email_to_user_id.get(email)
         is_excluded = user_id in pr_warning_excluded_members
 
-        # PR 경고 활성화 여부
         pr_warning_enabled = (
             squad.pr_warning
             and squad.squad.notion_db.properties.pr is not None
             and not is_excluded
         )
 
-        # 인원별 메시지 생성
         person_message = f"{assignee_name}\n"
         for task in tasks:
             task_line = format_task_line(task, pr_warning_enabled)
@@ -221,51 +134,30 @@ def send_team_scrum(
         thread_messages.append(person_message.strip())
 
     if dry_run:
-        # Dry run 모드에서는 콘솔에만 출력
+        print(f"\n[{squad.squad.display_name}] 채널: {squad.channel_id}")
         if thread_messages:
             for msg in thread_messages:
                 print(f"  └─ {msg}")
         else:
             print(f"  └─ (진행 중인 태스크 없음)")
-    else:
-        # 실제 메시지 발송
-        response = slack_client.chat_postMessage(
-            channel=squad.channel_id,
-            text=text,
+        return
+
+    # 9시 스크럼 스레드 ts 찾기
+    found = find_thread_ts_by_text(
+        slack_client, squad.channel_id, [squad.squad.display_name]
+    )
+    thread_ts = found.get(squad.squad.display_name)
+    if not thread_ts:
+        print(
+            f"[{squad.squad.display_name}] 스크럼 스레드를 찾지 못해 답글을 건너뜁니다."
         )
-        thread_ts = response["ts"]
+        return
 
-        # 인원별 메시지를 스레드에 발송
-        for msg in thread_messages:
-            slack_client.chat_postMessage(
-                channel=squad.channel_id,
-                thread_ts=thread_ts,
-                text=msg,
-            )
-
-
-def send_personal_scrum(
-    slack_client: WebClient,
-    personal: PersonalScrum,
-    dry_run: bool = False,
-):
-    """
-    개인 스크럼 메시지 발송
-
-    Args:
-        slack_client: Slack WebClient
-        personal: 개인 스크럼 설정
-        dry_run: True면 Slack에 메시지를 보내지 않고 콘솔에만 출력
-    """
-    text = personal.name
-
-    if dry_run:
-        print(f"\n[{personal.name}] 채널: {personal.channel_id}")
-        print(text)
-    else:
+    for msg in thread_messages:
         slack_client.chat_postMessage(
-            channel=personal.channel_id,
-            text=text,
+            channel=squad.channel_id,
+            thread_ts=thread_ts,
+            text=msg,
         )
 
 

--- a/scripts/schedule_scrum_mention.py
+++ b/scripts/schedule_scrum_mention.py
@@ -46,9 +46,9 @@ def main():
     for team_name, entry in team_entries.items():
         channel_to_team_names[entry["channel_id"]].append(team_name)
 
-    # 16:00에 보낸 스크럼 메시지 찾기 (최근 2시간 이내)
+    # 9시에 보낸 스크럼 메시지 찾기 (최근 12시간 이내)
     now = time.time()
-    oldest = now - 3600 * 2  # 2시간 전
+    oldest = now - 3600 * 12  # 12시간 전
 
     print(f"현재 시간: {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(now))}")
     print(

--- a/service/slack.py
+++ b/service/slack.py
@@ -2,9 +2,46 @@
 Slack API를 활용하는 Service Layer입니다.
 """
 
+import time
 from typing import Any
 from slack_sdk import WebClient
 from slack_sdk.web.async_client import AsyncWebClient
+
+
+def find_thread_ts_by_text(
+    slack_client: WebClient,
+    channel_id: str,
+    search_texts: list[str],
+    hours: int = 12,
+) -> dict[str, str]:
+    """
+    채널에서 최근 N시간 이내 메시지 중 search_texts 항목을 포함한 메시지의 ts를 찾는다.
+
+    Args:
+        slack_client: Slack WebClient
+        channel_id: 검색 대상 채널 ID
+        search_texts: 메시지 본문에 포함되어야 할 텍스트 목록
+        hours: 검색 시간 범위 (시간 단위)
+
+    Returns:
+        dict[str, str]: search_text -> thread_ts 매핑 (못 찾은 항목은 키 없음)
+    """
+    oldest = time.time() - 3600 * hours
+    response = slack_client.conversations_history(
+        channel=channel_id,
+        oldest=str(int(oldest)),
+        limit=200,
+    )
+
+    found: dict[str, str] = {}
+    for message in response.get("messages", []):
+        text = message.get("text", "")
+        for search_text in search_texts:
+            if search_text in found:
+                continue
+            if search_text in text:
+                found[search_text] = message["ts"]
+    return found
 
 
 def get_email_to_user_id(slack_client: WebClient) -> dict[str, str]:


### PR DESCRIPTION
## 배경

기존 `post_scrum_message`(16:00)는 안내·껍데기 메시지와 Notion 진행 태스크 요약을 한꺼번에 보냈다. 사용자가 채널 인사·작성 안내(껍데기)를 아침 일찍 받아 보고 싶다는 요청이 있어, 발송 시점을 분리.

## 변경사항

- `scripts/post_scrum_intro.py` 신규: 09:00 KST에 채널 안내 메시지 + 팀/개인 스크럼 메인 메시지(껍데기)를 발송
- `scripts/post_scrum_message.py`: 16:00 KST에 9시 스레드를 찾아 진행 중 Notion 태스크 요약을 답글로만 발송하도록 축소 (`reply_team_scrum_tasks`)
- `scripts/schedule_scrum_mention.py`: 스레드 검색 윈도우 2시간 → 12시간 (9시 메시지에 16:30 멘션을 달기 위함)
- `service/slack.py`: 채널 히스토리에서 텍스트 매칭으로 `thread_ts`를 찾는 헬퍼 `find_thread_ts_by_text` 추가
- `config.yaml`: `post_scrum_intro` 09:00 mon-fri 잡 추가, `post_scrum_message`는 16:00 유지

intro 문구도 아침 발송에 맞춰 인사 형태로 변경. 4:40 작성 마감 안내는 유지.

```
09:00  post_scrum_intro          (안내 + 팀/개인 껍데기 메인 메시지)
16:00  post_scrum_message        (9시 스레드에 Notion 태스크 요약 답글)
16:30  summarize_deployment      (기존 유지)
16:30  schedule_scrum_mention    (9시 스레드에 작성 멘션 답글)
```

## 대안

- intro만 9시로 옮기고 팀 껍데기 메시지는 16시 유지: 사용자 사용 흐름과 어긋남(아침에 받은 안내와 작성 스레드가 분리됨). 채택하지 않음.
- 9시 메시지 ts를 파일/DB에 저장해 16시·16:30에 전달: 외부 상태 의존이 늘고 단일 채널·일자에서는 텍스트 매칭으로 충분. 채택하지 않음.

## 검증

- [x] `python scripts/post_scrum_intro.py --dry-run` 정상 출력 (인사 + 모든 스쿼드/개인 껍데기)
- [x] `python scripts/post_scrum_message.py --dry-run` 정상 출력 (스쿼드별 인원 태스크 요약)
- [x] `pytest -q` 73 pass / 1 skip
- [x] `black --check` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)