### PR TITLE
chore: jce-landing-react main 보호 정책 강화 (배포 인지 체크 강제)

### DIFF
--- a/scripts/github_admin/repo_rulesets_config.json
+++ b/scripts/github_admin/repo_rulesets_config.json
@@ -4,7 +4,7 @@
   },
   "jce-landing-react": {
     "skip": ["ruleset.json", "ruleset_develop.json"],
-    "add": ["ruleset_main_force_push_only.json"]
+    "add": ["ruleset_main_landing_react.json"]
   },
   "tmn-e2e-video": {
     "skip": ["ruleset.json"]

--- a/scripts/github_admin/ruleset_main_landing_react.json
+++ b/scripts/github_admin/ruleset_main_landing_react.json
@@ -1,0 +1,54 @@
+{
+  "name": "Main Deploy Guard By Security",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          {
+            "context": "Deploy Acknowledgment"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 10349524,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
## 변경사항

`jce-landing-react`는 main 머지 즉시 ArgoCD auto-sync 로 운영(ai.codle.io)에 배포되는 유일한 흐름이라 인지 부족으로 인한 사고가 있었다. team-monolith-product/jce-landing-react#38 에서 PR 본문 체크박스 강제 + GitHub Action 검증을 추가하므로, 본 PR은 그 Action 을 ruleset 에서 required status check 으로 등록하여 미체크 시 머지를 차단한다.

- `scripts/github_admin/ruleset_main_landing_react.json` 신설 — 기존 `ruleset_main_force_push_only.json`(force-push/deletion 차단)에 `pull_request` rule + `required_status_checks` rule(`Deploy Acknowledgment` 컨텍스트) 추가. bypass actor 동일.
- `scripts/github_admin/repo_rulesets_config.json` 의 `jce-landing-react` 항목에서 `ruleset_main_force_push_only.json` → `ruleset_main_landing_react.json` 으로 교체.

적용 후 기존 `Main Force Push Protection By Security` ruleset은 add_ruleset.py 가 자동 정리하지 않으므로 GitHub UI/API 로 수동 삭제 필요. 새 ruleset 이 force-push/deletion 보호를 동일하게 포함하므로 중간 공백 없음.