### PR TITLE
feat: 인프라 과업 생성 시 활성 프로젝트 할당 및 영역 지정

### DIFF
--- a/app/common.py
+++ b/app/common.py
@@ -222,6 +222,20 @@ def get_component_options(client: NotionClient, data_source_id: str) -> list[str
     return []
 
 
+def get_area_options(client: NotionClient, data_source_id: str) -> list[str]:
+    """
+    노션 데이터 소스에서 영역 속성의 가능한 옵션들을 조회한다.
+    """
+    ds_schema = get_data_source_schema(client, data_source_id)
+    area_property = ds_schema["properties"].get("영역", {})
+
+    if "multi_select" in area_property:
+        options = area_property["multi_select"].get("options", [])
+        return [option["name"] for option in options]
+
+    return []
+
+
 def get_active_projects(
     client: NotionClient, project_data_source_id: str
 ) -> dict[str, str]:
@@ -320,6 +334,7 @@ def get_create_notion_task_tool(
     # 데이터 소스에서 실제 옵션들을 가져와서 동적으로 스키마 구성
     task_type_options = get_task_type_options(notion, data_source_id)
     component_options = get_component_options(notion, data_source_id)
+    area_options = get_area_options(notion, data_source_id)
 
     active_projects: dict[str, str] = {}
     if project_data_source_id:
@@ -346,6 +361,15 @@ def get_create_notion_task_tool(
             Field(
                 description=f"작업의 구성요소. 가능한 값: {', '.join(component_options)}",
                 json_schema_extra={"enum": component_options},
+            ),
+        )
+
+    if area_options:
+        fields["area"] = (
+            str,
+            Field(
+                description=f"작업의 영역. 반드시 지정해야 합니다. 가능한 값: {', '.join(area_options)}",
+                json_schema_extra={"enum": area_options},
             ),
         )
 
@@ -390,6 +414,7 @@ def get_create_notion_task_tool(
         title: str,
         task_type: str | None = None,
         component: str | None = None,
+        area: str | None = None,
         project: str | None = None,
         blocks: str | None = None,
     ) -> str:
@@ -412,6 +437,8 @@ def get_create_notion_task_tool(
             properties["유형"] = {"select": {"name": task_type}}
         if component and component_options:
             properties["구성요소"] = {"multi_select": [{"name": component}]}
+        if area and area_options:
+            properties["영역"] = {"multi_select": [{"name": area}]}
         if project and active_projects:
             properties["프로젝트"] = {"relation": [{"id": active_projects[project]}]}
 

--- a/app/general.py
+++ b/app/general.py
@@ -26,11 +26,6 @@ from .common import (
 )
 from service.config import load_config, Squad
 
-# 상수들
-# Notion API 2025-09-03 버전부터 data_source_id를 직접 사용
-DATA_SOURCE_ID: str = "3e050c5a-11f3-4a3e-b6d0-498fe06c9d7b"  # 작업 DB (기본값)
-PROJECT_DATA_SOURCE_ID: str = "1023943f-84d1-4223-a5a6-0c26e22d09f0"  # 프로젝트 DB
-
 # 유저그룹 멤버 캐시 (1시간 TTL)
 _cache_usergroup_members: TTLCache = TTLCache(maxsize=20, ttl=3600)
 
@@ -114,14 +109,15 @@ def register_general_handlers(app, assistant):
 
         # 사용자의 스쿼드에 따라 대상 Notion DB 결정
         squad = await _get_user_squad(app.client, user)
-        if squad and squad.notion_db.name != "main":
-            task_ds_id = squad.notion_db.data_source_id
-            title_prop = squad.notion_db.properties.title
-            project_ds_id = None
+        if squad:
+            db_config = squad.notion_db
         else:
-            task_ds_id = DATA_SOURCE_ID
-            title_prop = "제목"
-            project_ds_id = PROJECT_DATA_SOURCE_ID
+            config = load_config()
+            db_config = config.notion_databases["main"]
+
+        task_ds_id = db_config.data_source_id
+        title_prop = db_config.properties.title
+        project_ds_id = db_config.project_data_source_id
 
         # General Agent 사용
         notion_tools = [
@@ -219,14 +215,15 @@ def register_general_handlers(app, assistant):
 
         # 사용자의 스쿼드에 따라 대상 Notion DB 결정
         squad = await _get_user_squad(app.client, context.user_id)
-        if squad and squad.notion_db.name != "main":
-            task_ds_id = squad.notion_db.data_source_id
-            title_prop = squad.notion_db.properties.title
-            project_ds_id = None
+        if squad:
+            db_config = squad.notion_db
         else:
-            task_ds_id = DATA_SOURCE_ID
-            title_prop = "제목"
-            project_ds_id = PROJECT_DATA_SOURCE_ID
+            config = load_config()
+            db_config = config.notion_databases["main"]
+
+        task_ds_id = db_config.data_source_id
+        title_prop = db_config.properties.title
+        project_ds_id = db_config.project_data_source_id
 
         notion_tools = [
             get_create_notion_task_tool(

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 notion_databases:
   main:
     data_source_id: "3e050c5a-11f3-4a3e-b6d0-498fe06c9d7b"
+    project_data_source_id: "1023943f-84d1-4223-a5a6-0c26e22d09f0"
     properties:
       title: "제목"
       status: "상태"
@@ -27,6 +28,7 @@ notion_databases:
 
   infra:
     data_source_id: "3321cc82-0da6-80bf-b9b9-000b75cd1933"
+    project_data_source_id: "1023943f-84d1-4223-a5a6-0c26e22d09f0"
     properties:
       title: "이름"
       status: "상태"

--- a/service/config.py
+++ b/service/config.py
@@ -36,6 +36,7 @@ class NotionDBConfig:
     properties: NotionDBProperties
     pending_statuses: list[str] = field(default_factory=list)
     in_progress_statuses: list[str] = field(default_factory=list)
+    project_data_source_id: str | None = None
 
 
 # --- 조직 SOT ---
@@ -170,6 +171,7 @@ def _parse_config(raw: dict) -> AppConfig:
             ),
             pending_statuses=db_raw.get("pending_statuses", []),
             in_progress_statuses=db_raw.get("in_progress_statuses", []),
+            project_data_source_id=db_raw.get("project_data_source_id"),
         )
 
     # Squads (조직 SOT)


### PR DESCRIPTION
## Summary
- 인프라 팀이 로봇으로 과업 생성 시, 활성 프로젝트를 할당하고 영역을 올바르게 지정할 수 있도록 개선
- `config.yaml`에 `project_data_source_id` 설정을 추가하여 스쿼드별 프로젝트 DB를 설정 가능하게 변경
- `general.py`의 하드코딩된 데이터 소스 상수를 config 기반으로 전환

## Changes

### Config (`config.yaml`, `service/config.py`)
- `NotionDBConfig`에 `project_data_source_id` 옵션 필드 추가
- `main`과 `infra` DB에 동일한 프로젝트 데이터 소스 ID 설정

### Task Creation (`app/common.py`)
- `get_area_options()` 함수 추가: 데이터 소스에서 `영역` multi_select 옵션 자동 조회
- `create_notion_task` 도구에 `area` 파라미터 추가 (LLM이 영역을 선택하도록)
- 과업 생성 시 `영역` 속성 자동 설정

### Bot Handler (`app/general.py`)
- 하드코딩된 `DATA_SOURCE_ID`, `PROJECT_DATA_SOURCE_ID` 상수 제거
- 모든 스쿼드가 config의 `project_data_source_id`를 사용하도록 통합
- 인프라 팀 포함 전체 스쿼드에서 프로젝트 할당 가능

## Test plan
- [ ] 인프라 팀 멤버가 봇에게 과업 생성 요청 시 영역 옵션이 제공되는지 확인
- [ ] 생성된 과업에 프로젝트가 올바르게 할당되는지 확인
- [ ] 기존 메인(코들) 스쿼드의 과업 생성이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)