### PR TITLE
fix: 스케줄러 misfire_grace_time 추가로 파드 재시작 후 작업 누락 방지

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -50,7 +50,13 @@ def start_scheduler():
         )
 
         trigger = CronTrigger(timezone=TIMEZONE, **job_config.cron)
-        scheduler.add_job(wrapped, trigger, id=job_config.name, name=job_config.name)
+        scheduler.add_job(
+            wrapped,
+            trigger,
+            id=job_config.name,
+            name=job_config.name,
+            misfire_grace_time=3600,
+        )
         print(f"[scheduler] 작업 등록: {job_config.name} ({trigger})")
 
     scheduler.start()


### PR DESCRIPTION
## Summary
- APScheduler의 `misfire_grace_time`을 1시간(3600초)으로 설정하여 파드 재시작 후에도 예정된 작업이 누락되지 않도록 함
- 기본값(1초)에서는 파드 재시작 시점에 이미 지나간 작업이 조용히 건너뛰어짐

## Background
2026-05-18 slackbot 파드가 14:12에 OOMKilled(400Mi 한도 초과)되어 재시작된 후, 16:00 `post_scrum_message`와 16:30 `schedule_scrum_mention` 작업이 누락됨.

## 추가 필요 작업
- slackbot 파드 메모리 한도 상향 필요 (현재 400Mi → 최소 512Mi 권장). Helm chart 수정 필요.

## Test plan
- [ ] CI 테스트 통과 확인
- [ ] 배포 후 다음 영업일 스케줄러 작업 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)