### PR TITLE
[INF-192] 연수 사업 디스코드 수업 종료 공지 봇

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,16 @@ GITHUB_ORG_NAME=your-organization-name
 # Justin Bot Configuration (미팅 보고서/제안서 자동 피드백)
 SLACK_BOT_TOKEN_JUSTIN=xoxb-your-justin-bot-token
 SLACK_APP_TOKEN_JUSTIN=xapp-your-justin-app-token
+
+# Discord Bot Configuration (연수 사업 수업 종료 공지)
+DISCORD_BOT_TOKEN=your-discord-bot-token
+DISCORD_GUILD_ID=1504338147155251220
+# 간식증빙사진, 출석부사진, 수업사진 순서
+DISCORD_TEMPLATE_THREAD_IDS=1504690676661489715,1504690556297809981,1504690489364840488
+DISCORD_TEMPLATE_CHANNEL_ID=1504375083546972230
+DISCORD_LOG_CHANNEL_ID=1505927819094397038
+
+# Google Sheets Configuration
+GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"..."}
+GOOGLE_SPREADSHEET_ID=1ZP7wyxbwRO2AhyzForm7494C6bMbY_HAeNHV6-WbSnc
+GOOGLE_WORKSHEET_ID=451387449

--- a/api/discord.py
+++ b/api/discord.py
@@ -50,6 +50,18 @@ def get_message(channel_id: str, message_id: str) -> dict:
     return resp.json()
 
 
+def get_channel_messages(channel_id: str, limit: int = 100) -> list[dict]:
+    """채널의 최근 메시지 목록 조회 (최신순)"""
+    resp = requests.get(
+        f"{BASE_URL}/channels/{channel_id}/messages",
+        headers=_headers(),
+        params={"limit": limit},
+        timeout=REQUEST_TIMEOUT,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
 def get_active_threads(guild_id: str) -> dict:
     """서버의 활성 스레드 목록 조회"""
     resp = requests.get(

--- a/api/discord.py
+++ b/api/discord.py
@@ -1,0 +1,140 @@
+"""
+Discord API 래퍼 함수
+"""
+
+import os
+
+import requests
+
+BASE_URL = "https://discord.com/api/v10"
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bot {os.environ['DISCORD_BOT_TOKEN']}",
+        "Content-Type": "application/json",
+    }
+
+
+def get_guild_channels(guild_id: str) -> list[dict]:
+    """서버의 모든 채널 목록 조회"""
+    resp = requests.get(f"{BASE_URL}/guilds/{guild_id}/channels", headers=_headers())
+    resp.raise_for_status()
+    return resp.json()
+
+
+def find_forum_channel(guild_id: str, channel_name: str) -> dict | None:
+    """
+    서버에서 이름이 일치하는 포럼 채널을 찾는다.
+
+    Args:
+        guild_id: Discord 서버 ID
+        channel_name: 찾을 채널 이름 (예: "선인고등학교-공지")
+
+    Returns:
+        채널 dict 또는 None
+    """
+    channels = get_guild_channels(guild_id)
+    for ch in channels:
+        # type 15 = Forum channel
+        if ch.get("type") == 15 and ch.get("name") == channel_name:
+            return ch
+    return None
+
+
+def fetch_message(channel_id: str, message_id: str) -> dict:
+    """특정 채널의 메시지를 가져온다."""
+    resp = requests.get(
+        f"{BASE_URL}/channels/{channel_id}/messages/{message_id}",
+        headers=_headers(),
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_channel(channel_id: str) -> dict:
+    """채널 정보를 가져온다."""
+    resp = requests.get(f"{BASE_URL}/channels/{channel_id}", headers=_headers())
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_thread_template(thread_id: str) -> dict:
+    """
+    포럼 스레드(게시물)의 제목과 본문을 가져온다.
+
+    Returns:
+        {"title": "yymmdd_간식증빙사진", "content": "-"}
+    """
+    channel = get_channel(thread_id)
+    title = channel.get("name", "")
+
+    # 스레드의 첫 메시지 가져오기 (thread_id == channel_id에서 가장 오래된 메시지)
+    resp = requests.get(
+        f"{BASE_URL}/channels/{thread_id}/messages",
+        headers=_headers(),
+        params={"limit": 1, "sort_order": "asc"},
+    )
+    resp.raise_for_status()
+    messages = resp.json()
+    content = messages[0].get("content", "") if messages else ""
+
+    return {"title": title, "content": content}
+
+
+def get_active_threads(guild_id: str) -> list[dict]:
+    """서버의 활성 스레드 목록 조회"""
+    resp = requests.get(
+        f"{BASE_URL}/guilds/{guild_id}/threads/active",
+        headers=_headers(),
+    )
+    resp.raise_for_status()
+    return resp.json().get("threads", [])
+
+
+def get_recent_threads_in_forum(guild_id: str, forum_channel_id: str) -> list[dict]:
+    """
+    포럼 채널의 최근 스레드(게시물) 목록을 가져온다.
+    활성 스레드 중 해당 포럼에 속한 것만 필터링.
+    """
+    threads = get_active_threads(guild_id)
+    return [t for t in threads if t.get("parent_id") == forum_channel_id]
+
+
+def create_forum_thread(
+    channel_id: str, title: str, content: str
+) -> dict:
+    """
+    포럼 채널에 새 게시물(스레드)을 생성한다.
+
+    Args:
+        channel_id: 포럼 채널 ID
+        title: 게시물 제목
+        content: 게시물 본문
+
+    Returns:
+        생성된 스레드 dict
+    """
+    payload = {
+        "name": title,
+        "message": {"content": content},
+    }
+    resp = requests.post(
+        f"{BASE_URL}/channels/{channel_id}/threads",
+        headers=_headers(),
+        json=payload,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def send_message(channel_id: str, content: str) -> dict:
+    """일반 채널에 메시지를 보낸다."""
+    payload = {"content": content}
+    resp = requests.post(
+        f"{BASE_URL}/channels/{channel_id}/messages",
+        headers=_headers(),
+        json=payload,
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/api/discord.py
+++ b/api/discord.py
@@ -7,6 +7,7 @@ import os
 import requests
 
 BASE_URL = "https://discord.com/api/v10"
+REQUEST_TIMEOUT = 10
 
 
 def _headers() -> dict[str, str]:
@@ -18,14 +19,22 @@ def _headers() -> dict[str, str]:
 
 def get_guild_channels(guild_id: str) -> list[dict]:
     """서버의 모든 채널 목록 조회"""
-    resp = requests.get(f"{BASE_URL}/guilds/{guild_id}/channels", headers=_headers())
+    resp = requests.get(
+        f"{BASE_URL}/guilds/{guild_id}/channels",
+        headers=_headers(),
+        timeout=REQUEST_TIMEOUT,
+    )
     resp.raise_for_status()
     return resp.json()
 
 
 def get_channel(channel_id: str) -> dict:
     """채널(스레드 포함) 정보 조회"""
-    resp = requests.get(f"{BASE_URL}/channels/{channel_id}", headers=_headers())
+    resp = requests.get(
+        f"{BASE_URL}/channels/{channel_id}",
+        headers=_headers(),
+        timeout=REQUEST_TIMEOUT,
+    )
     resp.raise_for_status()
     return resp.json()
 
@@ -35,6 +44,7 @@ def get_message(channel_id: str, message_id: str) -> dict:
     resp = requests.get(
         f"{BASE_URL}/channels/{channel_id}/messages/{message_id}",
         headers=_headers(),
+        timeout=REQUEST_TIMEOUT,
     )
     resp.raise_for_status()
     return resp.json()
@@ -45,6 +55,7 @@ def get_active_threads(guild_id: str) -> dict:
     resp = requests.get(
         f"{BASE_URL}/guilds/{guild_id}/threads/active",
         headers=_headers(),
+        timeout=REQUEST_TIMEOUT,
     )
     resp.raise_for_status()
     return resp.json()
@@ -60,6 +71,7 @@ def create_thread(channel_id: str, name: str, content: str) -> dict:
         f"{BASE_URL}/channels/{channel_id}/threads",
         headers=_headers(),
         json=payload,
+        timeout=REQUEST_TIMEOUT,
     )
     resp.raise_for_status()
     return resp.json()
@@ -72,6 +84,7 @@ def create_message(channel_id: str, content: str) -> dict:
         f"{BASE_URL}/channels/{channel_id}/messages",
         headers=_headers(),
         json=payload,
+        timeout=REQUEST_TIMEOUT,
     )
     resp.raise_for_status()
     return resp.json()

--- a/api/discord.py
+++ b/api/discord.py
@@ -101,9 +101,7 @@ def get_recent_threads_in_forum(guild_id: str, forum_channel_id: str) -> list[di
     return [t for t in threads if t.get("parent_id") == forum_channel_id]
 
 
-def create_forum_thread(
-    channel_id: str, title: str, content: str
-) -> dict:
+def create_forum_thread(channel_id: str, title: str, content: str) -> dict:
     """
     포럼 채널에 새 게시물(스레드)을 생성한다.
 

--- a/api/discord.py
+++ b/api/discord.py
@@ -23,27 +23,15 @@ def get_guild_channels(guild_id: str) -> list[dict]:
     return resp.json()
 
 
-def find_forum_channel(guild_id: str, channel_name: str) -> dict | None:
-    """
-    서버에서 이름이 일치하는 포럼 채널을 찾는다.
-
-    Args:
-        guild_id: Discord 서버 ID
-        channel_name: 찾을 채널 이름 (예: "선인고등학교-공지")
-
-    Returns:
-        채널 dict 또는 None
-    """
-    channels = get_guild_channels(guild_id)
-    for ch in channels:
-        # type 15 = Forum channel
-        if ch.get("type") == 15 and ch.get("name") == channel_name:
-            return ch
-    return None
+def get_channel(channel_id: str) -> dict:
+    """채널(스레드 포함) 정보 조회"""
+    resp = requests.get(f"{BASE_URL}/channels/{channel_id}", headers=_headers())
+    resp.raise_for_status()
+    return resp.json()
 
 
-def fetch_message(channel_id: str, message_id: str) -> dict:
-    """특정 채널의 메시지를 가져온다."""
+def get_message(channel_id: str, message_id: str) -> dict:
+    """특정 채널의 메시지 조회"""
     resp = requests.get(
         f"{BASE_URL}/channels/{channel_id}/messages/{message_id}",
         headers=_headers(),
@@ -52,69 +40,20 @@ def fetch_message(channel_id: str, message_id: str) -> dict:
     return resp.json()
 
 
-def get_channel(channel_id: str) -> dict:
-    """채널 정보를 가져온다."""
-    resp = requests.get(f"{BASE_URL}/channels/{channel_id}", headers=_headers())
-    resp.raise_for_status()
-    return resp.json()
-
-
-def fetch_thread_template(thread_id: str) -> dict:
-    """
-    포럼 스레드(게시물)의 제목과 본문을 가져온다.
-
-    Returns:
-        {"title": "yymmdd_간식증빙사진", "content": "-"}
-    """
-    channel = get_channel(thread_id)
-    title = channel.get("name", "")
-
-    # 스레드의 첫 메시지 가져오기 (thread_id == channel_id에서 가장 오래된 메시지)
-    resp = requests.get(
-        f"{BASE_URL}/channels/{thread_id}/messages",
-        headers=_headers(),
-        params={"limit": 1, "sort_order": "asc"},
-    )
-    resp.raise_for_status()
-    messages = resp.json()
-    content = messages[0].get("content", "") if messages else ""
-
-    return {"title": title, "content": content}
-
-
-def get_active_threads(guild_id: str) -> list[dict]:
+def get_active_threads(guild_id: str) -> dict:
     """서버의 활성 스레드 목록 조회"""
     resp = requests.get(
         f"{BASE_URL}/guilds/{guild_id}/threads/active",
         headers=_headers(),
     )
     resp.raise_for_status()
-    return resp.json().get("threads", [])
+    return resp.json()
 
 
-def get_recent_threads_in_forum(guild_id: str, forum_channel_id: str) -> list[dict]:
-    """
-    포럼 채널의 최근 스레드(게시물) 목록을 가져온다.
-    활성 스레드 중 해당 포럼에 속한 것만 필터링.
-    """
-    threads = get_active_threads(guild_id)
-    return [t for t in threads if t.get("parent_id") == forum_channel_id]
-
-
-def create_forum_thread(channel_id: str, title: str, content: str) -> dict:
-    """
-    포럼 채널에 새 게시물(스레드)을 생성한다.
-
-    Args:
-        channel_id: 포럼 채널 ID
-        title: 게시물 제목
-        content: 게시물 본문
-
-    Returns:
-        생성된 스레드 dict
-    """
+def create_thread(channel_id: str, name: str, content: str) -> dict:
+    """포럼 채널에 새 게시물(스레드) 생성"""
     payload = {
-        "name": title,
+        "name": name,
         "message": {"content": content},
     }
     resp = requests.post(
@@ -126,8 +65,8 @@ def create_forum_thread(channel_id: str, title: str, content: str) -> dict:
     return resp.json()
 
 
-def send_message(channel_id: str, content: str) -> dict:
-    """일반 채널에 메시지를 보낸다."""
+def create_message(channel_id: str, content: str) -> dict:
+    """채널에 메시지 생성"""
     payload = {"content": content}
     resp = requests.post(
         f"{BASE_URL}/channels/{channel_id}/messages",

--- a/api/google_sheets.py
+++ b/api/google_sheets.py
@@ -4,17 +4,11 @@ Google Sheets API 래퍼 함수
 
 import json
 import os
-from datetime import datetime, timedelta, timezone
 
 import gspread
 from google.oauth2.service_account import Credentials
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
-
-KST = timezone(timedelta(hours=9))
-
-# Google Sheets 날짜 기준일 (1899-12-30)
-_SHEETS_EPOCH = datetime(1899, 12, 30, tzinfo=KST)
 
 
 def _get_client() -> gspread.Client:
@@ -25,84 +19,12 @@ def _get_client() -> gspread.Client:
     return gspread.authorize(creds)
 
 
-def _serial_to_date(serial: int | float) -> datetime | None:
-    """Google Sheets 날짜 시리얼 값을 datetime으로 변환"""
-    if not serial:
-        return None
-    return _SHEETS_EPOCH + timedelta(days=int(serial))
-
-
-def _serial_to_time(serial: int | float) -> tuple[int, int] | None:
-    """Google Sheets 시간 시리얼 값(하루의 비율)을 (hour, minute) 튜플로 변환"""
-    if not serial:
-        return None
-    total_minutes = round(serial * 1440)
-    return (total_minutes // 60, total_minutes % 60)
-
-
-def read_school_schedules(spreadsheet_id: str, worksheet_id: int) -> list[dict]:
+def get_worksheet_values(spreadsheet_id: str, worksheet_id: int) -> list[list]:
     """
-    학교별 수업 일정을 읽어온다.
-
-    시트 스키마: 학교명 | 날짜1 | 시작1 | 종료1 | 날짜2 | 시작2 | 종료2 | ...
-    UNFORMATTED_VALUE로 읽어 날짜는 시리얼 숫자, 시간은 하루 비율로 반환됨.
-
-    Args:
-        spreadsheet_id: Google Sheets 파일 ID
-        worksheet_id: 시트(탭) ID
-
-    Returns:
-        [
-            {
-                "school_name": "선인고등학교",
-                "schedules": [
-                    {"date": datetime, "start_hour": 13, "start_min": 30, "end_hour": 17, "end_min": 30},
-                    ...
-                ]
-            },
-            ...
-        ]
+    워크시트의 모든 셀 값을 UNFORMATTED_VALUE 형태로 반환한다.
+    날짜는 시리얼 숫자, 시간은 하루의 비율(0.0~1.0)로 반환됨.
     """
     gc = _get_client()
     sh = gc.open_by_key(spreadsheet_id)
     ws = sh.get_worksheet_by_id(worksheet_id)
-    rows = ws.get_all_values(value_render_option="UNFORMATTED_VALUE")
-
-    results = []
-    for row in rows[1:]:  # 헤더 스킵
-        school_name = str(row[0]).strip() if row else ""
-        if not school_name:
-            continue
-
-        schedules = []
-        # 컬럼 1부터 3개씩 (날짜, 시작, 종료)
-        col = 1
-        while col + 2 < len(row):
-            date_val = row[col]
-            start_val = row[col + 1]
-            end_val = row[col + 2]
-
-            if not date_val:
-                col += 3
-                continue
-
-            date = _serial_to_date(date_val)
-            start = _serial_to_time(start_val)
-            end = _serial_to_time(end_val)
-
-            if date and start and end:
-                schedules.append(
-                    {
-                        "date": date,
-                        "start_hour": start[0],
-                        "start_min": start[1],
-                        "end_hour": end[0],
-                        "end_min": end[1],
-                    }
-                )
-
-            col += 3
-
-        results.append({"school_name": school_name, "schedules": schedules})
-
-    return results
+    return ws.get_all_values(value_render_option="UNFORMATTED_VALUE")

--- a/api/google_sheets.py
+++ b/api/google_sheets.py
@@ -1,0 +1,106 @@
+"""
+Google Sheets API 래퍼 함수
+"""
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import gspread
+from google.oauth2.service_account import Credentials
+
+SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+
+KST = timezone(timedelta(hours=9))
+
+# Google Sheets 날짜 기준일 (1899-12-30)
+_SHEETS_EPOCH = datetime(1899, 12, 30, tzinfo=KST)
+
+
+def _get_client() -> gspread.Client:
+    """환경 변수에서 서비스 계정 JSON을 읽어 gspread 클라이언트 생성"""
+    sa_json = os.environ["GOOGLE_SERVICE_ACCOUNT_JSON"]
+    info = json.loads(sa_json)
+    creds = Credentials.from_service_account_info(info, scopes=SCOPES)
+    return gspread.authorize(creds)
+
+
+def _serial_to_date(serial: int | float) -> datetime | None:
+    """Google Sheets 날짜 시리얼 값을 datetime으로 변환"""
+    if not serial:
+        return None
+    return _SHEETS_EPOCH + timedelta(days=int(serial))
+
+
+def _serial_to_time(serial: int | float) -> tuple[int, int] | None:
+    """Google Sheets 시간 시리얼 값(하루의 비율)을 (hour, minute) 튜플로 변환"""
+    if not serial:
+        return None
+    total_minutes = round(serial * 1440)
+    return (total_minutes // 60, total_minutes % 60)
+
+
+def read_school_schedules(spreadsheet_id: str, worksheet_id: int) -> list[dict]:
+    """
+    학교별 수업 일정을 읽어온다.
+
+    시트 스키마: 학교명 | 날짜1 | 시작1 | 종료1 | 날짜2 | 시작2 | 종료2 | ...
+    UNFORMATTED_VALUE로 읽어 날짜는 시리얼 숫자, 시간은 하루 비율로 반환됨.
+
+    Args:
+        spreadsheet_id: Google Sheets 파일 ID
+        worksheet_id: 시트(탭) ID
+
+    Returns:
+        [
+            {
+                "school_name": "선인고등학교",
+                "schedules": [
+                    {"date": datetime, "start_hour": 13, "start_min": 30, "end_hour": 17, "end_min": 30},
+                    ...
+                ]
+            },
+            ...
+        ]
+    """
+    gc = _get_client()
+    sh = gc.open_by_key(spreadsheet_id)
+    ws = sh.get_worksheet_by_id(worksheet_id)
+    rows = ws.get_all_values(value_render_option="UNFORMATTED_VALUE")
+
+    results = []
+    for row in rows[1:]:  # 헤더 스킵
+        school_name = str(row[0]).strip() if row else ""
+        if not school_name:
+            continue
+
+        schedules = []
+        # 컬럼 1부터 3개씩 (날짜, 시작, 종료)
+        col = 1
+        while col + 2 < len(row):
+            date_val = row[col]
+            start_val = row[col + 1]
+            end_val = row[col + 2]
+
+            if not date_val:
+                col += 3
+                continue
+
+            date = _serial_to_date(date_val)
+            start = _serial_to_time(start_val)
+            end = _serial_to_time(end_val)
+
+            if date and start and end:
+                schedules.append({
+                    "date": date,
+                    "start_hour": start[0],
+                    "start_min": start[1],
+                    "end_hour": end[0],
+                    "end_min": end[1],
+                })
+
+            col += 3
+
+        results.append({"school_name": school_name, "schedules": schedules})
+
+    return results

--- a/api/google_sheets.py
+++ b/api/google_sheets.py
@@ -91,13 +91,15 @@ def read_school_schedules(spreadsheet_id: str, worksheet_id: int) -> list[dict]:
             end = _serial_to_time(end_val)
 
             if date and start and end:
-                schedules.append({
-                    "date": date,
-                    "start_hour": start[0],
-                    "start_min": start[1],
-                    "end_hour": end[0],
-                    "end_min": end[1],
-                })
+                schedules.append(
+                    {
+                        "date": date,
+                        "start_hour": start[0],
+                        "start_min": start[1],
+                        "end_hour": end[0],
+                        "end_min": end[1],
+                    }
+                )
 
             col += 3
 

--- a/api/google_sheets.py
+++ b/api/google_sheets.py
@@ -19,12 +19,21 @@ def _get_client() -> gspread.Client:
     return gspread.authorize(creds)
 
 
-def get_worksheet_values(spreadsheet_id: str, worksheet_id: int) -> list[list]:
+def get_worksheet_values(
+    spreadsheet_id: str,
+    worksheet_id: int,
+    value_render_option: str = "FORMATTED_VALUE",
+) -> list[list]:
     """
-    워크시트의 모든 셀 값을 UNFORMATTED_VALUE 형태로 반환한다.
-    날짜는 시리얼 숫자, 시간은 하루의 비율(0.0~1.0)로 반환됨.
+    워크시트의 모든 셀 값을 반환한다.
+
+    Args:
+        spreadsheet_id: 스프레드시트 ID
+        worksheet_id: 워크시트(탭) ID
+        value_render_option: "FORMATTED_VALUE" | "UNFORMATTED_VALUE" | "FORMULA"
+            (https://developers.google.com/sheets/api/reference/rest/v4/ValueRenderOption)
     """
     gc = _get_client()
     sh = gc.open_by_key(spreadsheet_id)
     ws = sh.get_worksheet_by_id(worksheet_id)
-    return ws.get_all_values(value_render_option="UNFORMATTED_VALUE")
+    return ws.get_all_values(value_render_option=value_render_option)

--- a/config.yaml
+++ b/config.yaml
@@ -273,10 +273,9 @@ scheduled_jobs:
       day: 1
     business_day_only: false
 
-  - name: discord_schedule_today_notices
+  - name: discord_post_completion_notice
     module: scripts.discord_post_completion_notice
-    function: schedule_today_notices
+    function: main
     cron:
-      hour: 7
-      minute: 0
+      minute: "*/10"
     business_day_only: false

--- a/config.yaml
+++ b/config.yaml
@@ -272,3 +272,11 @@ scheduled_jobs:
       minute: 0
       day: 1
     business_day_only: false
+
+  - name: discord_schedule_today_notices
+    module: scripts.discord_post_completion_notice
+    function: schedule_today_notices
+    cron:
+      hour: 7
+      minute: 0
+    business_day_only: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,5 @@ anthropic
 sentry-sdk[fastapi]
 PyYAML
 apscheduler
+gspread
+google-auth

--- a/scheduler.py
+++ b/scheduler.py
@@ -37,6 +37,12 @@ def _make_job_callable(func, job_name: str, business_day_only: bool):
     return wrapper
 
 
+def _inject_scheduler(module, scheduler):
+    """동적 잡 등록이 필요한 모듈에 스케줄러 인스턴스를 주입한다."""
+    if hasattr(module, "set_scheduler"):
+        module.set_scheduler(scheduler)
+
+
 def start_scheduler():
     """스케줄러를 생성하고 config.yaml의 작업을 등록한 뒤 시작"""
     config = load_config()
@@ -45,6 +51,9 @@ def start_scheduler():
     for job_config in config.scheduled_jobs:
         module = importlib.import_module(job_config.module)
         func = getattr(module, job_config.function)
+
+        _inject_scheduler(module, scheduler)
+
         wrapped = _make_job_callable(
             func, job_config.name, job_config.business_day_only
         )

--- a/scheduler.py
+++ b/scheduler.py
@@ -37,12 +37,6 @@ def _make_job_callable(func, job_name: str, business_day_only: bool):
     return wrapper
 
 
-def _inject_scheduler(module, scheduler):
-    """동적 잡 등록이 필요한 모듈에 스케줄러 인스턴스를 주입한다."""
-    if hasattr(module, "set_scheduler"):
-        module.set_scheduler(scheduler)
-
-
 def start_scheduler():
     """스케줄러를 생성하고 config.yaml의 작업을 등록한 뒤 시작"""
     config = load_config()
@@ -51,9 +45,6 @@ def start_scheduler():
     for job_config in config.scheduled_jobs:
         module = importlib.import_module(job_config.module)
         func = getattr(module, job_config.function)
-
-        _inject_scheduler(module, scheduler)
-
         wrapped = _make_job_callable(
             func, job_config.name, job_config.business_day_only
         )

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -1,0 +1,208 @@
+"""
+수업 종료 후 Discord 포럼 채널에 자동 공지 게시
+
+두 단계로 동작:
+1. schedule_today_notices(): 매일 아침 크론으로 실행.
+   Google Sheets에서 오늘 일정을 읽고, 각 종료시각에 맞춰 APScheduler 1회성 job 등록.
+2. post_notice(): 등록된 종료시각에 실행.
+   해당 학교의 "{학교이름}-공지" 포럼 채널에 템플릿 기반 게시물 3개 작성.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import argparse
+import os
+from datetime import datetime, timedelta, timezone
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.date import DateTrigger
+from dotenv import load_dotenv
+
+from api.discord import (
+    create_forum_thread,
+    fetch_thread_template,
+    get_guild_channels,
+    send_message,
+)
+from api.google_sheets import read_school_schedules
+
+load_dotenv()
+
+KST = timezone(timedelta(hours=9))
+TIMEZONE = "Asia/Seoul"
+
+SPREADSHEET_ID = os.environ.get(
+    "GOOGLE_SPREADSHEET_ID", "1ZP7wyxbwRO2AhyzForm7494C6bMbY_HAeNHV6-WbSnc"
+)
+WORKSHEET_ID = int(os.environ.get("GOOGLE_WORKSHEET_ID", "451387449"))
+GUILD_ID = os.environ.get("DISCORD_GUILD_ID", "1504338147155251220")
+TEMPLATE_CHANNEL_ID = os.environ.get("DISCORD_TEMPLATE_CHANNEL_ID", "1504375083546972230")
+TEMPLATE_THREAD_IDS = [
+    tid.strip()
+    for tid in os.environ.get("DISCORD_TEMPLATE_THREAD_IDS", "").split(",")
+    if tid.strip()
+]
+LOG_CHANNEL_ID = os.environ.get("DISCORD_LOG_CHANNEL_ID", "1505927819094397038")
+
+DATE_PLACEHOLDER = "yymmdd"
+
+# 모듈 레벨 스케줄러 참조 (scheduler.py에서 주입)
+_scheduler = None
+
+
+def set_scheduler(scheduler):
+    """외부 스케줄러 인스턴스를 주입받는다."""
+    global _scheduler
+    _scheduler = scheduler
+
+
+def _fetch_templates() -> list[dict]:
+    """템플릿 스레드들을 fetch하여 제목/본문을 가져온다."""
+    templates = []
+    for thread_id in TEMPLATE_THREAD_IDS:
+        tmpl = fetch_thread_template(thread_id)
+        templates.append(tmpl)
+    return templates
+
+
+def post_notice(school_name: str, date_str: str):
+    """
+    특정 학교의 포럼 채널에 공지 게시물 3개를 작성한다.
+    APScheduler에 의해 종료시각에 호출된다.
+
+    Args:
+        school_name: 학교명
+        date_str: 날짜 문자열 (예: "260531")
+    """
+    channel_name = f"{school_name}-공지"
+    print(f"[post_notice] {channel_name} 공지 시작")
+
+    channels = get_guild_channels(GUILD_ID)
+    forum_channels = {ch["name"]: ch for ch in channels if ch.get("type") == 15}
+
+    channel = forum_channels.get(channel_name)
+    if not channel:
+        msg = f"[채널 없음] {channel_name}"
+        print(f"  {msg}")
+        if LOG_CHANNEL_ID:
+            send_message(LOG_CHANNEL_ID, msg)
+        return
+
+    channel_id = channel["id"]
+    templates = _fetch_templates()
+
+    for tmpl in templates:
+        new_title = tmpl["title"].replace(DATE_PLACEHOLDER, date_str)
+        create_forum_thread(channel_id, title=new_title, content=tmpl["content"])
+        print(f"  게시물 생성: {new_title}")
+
+    print(f"[post_notice] {channel_name} 공지 완료")
+
+
+def schedule_today_notices(scheduler=None):
+    """
+    오늘 수업이 있는 학교를 찾아 종료시각에 맞춰 1회성 job을 등록한다.
+    매일 아침 크론으로 호출된다.
+    """
+    sched = scheduler or _scheduler
+    if not sched:
+        print("[schedule_today_notices] 스케줄러가 없습니다.")
+        return
+
+    now = datetime.now(KST)
+    today = now.date()
+    today_str = now.strftime("%y%m%d")
+
+    print(f"[schedule_today_notices] {today} 일정 등록 시작")
+
+    schools = read_school_schedules(SPREADSHEET_ID, WORKSHEET_ID)
+    registered = 0
+
+    for school in schools:
+        for s in school["schedules"]:
+            if s["date"].date() != today:
+                continue
+
+            end_time = s["date"].replace(hour=s["end_hour"], minute=s["end_min"])
+
+            # 이미 지난 시각은 스킵
+            if end_time <= now:
+                continue
+
+            job_id = f"discord_notice_{school['school_name']}_{today_str}_{s['end_hour']:02d}{s['end_min']:02d}"
+
+            sched.add_job(
+                post_notice,
+                trigger=DateTrigger(run_date=end_time, timezone=TIMEZONE),
+                id=job_id,
+                name=job_id,
+                args=[school["school_name"], today_str],
+                replace_existing=True,
+            )
+            print(f"  등록: {school['school_name']} → {end_time.strftime('%H:%M')}")
+            registered += 1
+
+    print(f"[schedule_today_notices] {registered}개 job 등록 완료")
+
+
+def main(dry_run: bool = False, target_date: str | None = None):
+    """CLI용 엔트리포인트. dry-run 및 날짜 지정 테스트 지원."""
+    now = datetime.now(KST)
+
+    if target_date:
+        parts = target_date.split("-")
+        if len(parts) == 3:
+            year, month, day = int(parts[0]), int(parts[1]), int(parts[2])
+        elif len(parts) == 2:
+            year = now.year
+            month, day = int(parts[0]), int(parts[1])
+        else:
+            print(f"  잘못된 날짜 형식: {target_date} (YYYY-MM-DD 또는 MM-DD)")
+            return
+        target = datetime(year, month, day, tzinfo=KST).date()
+    else:
+        target = now.date()
+
+    today_str = target.strftime("%y%m%d")
+
+    print(f"[discord_post_completion_notice] 실행: {target}")
+
+    schools = read_school_schedules(SPREADSHEET_ID, WORKSHEET_ID)
+    print(f"  학교 수: {len(schools)}")
+
+    # 해당 날짜에 수업이 있는 학교 찾기
+    notices = []
+    for school in schools:
+        for s in school["schedules"]:
+            if s["date"].date() != target:
+                continue
+            end_time = s["date"].replace(hour=s["end_hour"], minute=s["end_min"])
+            notices.append((school["school_name"], end_time))
+
+    if not notices:
+        print("  공지 대상 학교 없음")
+        return
+
+    if dry_run:
+        for school_name, end_time in notices:
+            channel_name = f"{school_name}-공지"
+            print(f"  [DRY-RUN] {end_time.strftime('%H:%M')} → {channel_name}")
+            print(f"    → {today_str}_간식증빙사진")
+            print(f"    → {today_str}_출석부사진")
+            print(f"    → {today_str}_수업사진")
+        return
+
+    # 실제 실행 (--date로 수동 트리거)
+    for school_name, end_time in notices:
+        post_notice(school_name, today_str)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="수업 종료 후 Discord 공지 자동 게시")
+    parser.add_argument("--dry-run", action="store_true", help="실제 전송 없이 콘솔 출력만")
+    parser.add_argument("--date", type=str, help="대상 날짜 (YYYY-MM-DD 또는 MM-DD)")
+    args = parser.parse_args()
+    main(dry_run=args.dry_run, target_date=args.date)

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -18,7 +18,6 @@ import argparse
 import os
 from datetime import datetime, timedelta, timezone
 
-import redis
 import requests
 from dotenv import load_dotenv
 
@@ -27,6 +26,7 @@ from api.discord import (
     create_thread,
     get_active_threads,
     get_channel,
+    get_channel_messages,
     get_guild_channels,
     get_message,
 )
@@ -52,15 +52,12 @@ TEMPLATE_THREAD_IDS = [
 ]
 LOG_CHANNEL_ID = os.environ.get("DISCORD_LOG_CHANNEL_ID", "1505927819094397038")
 
-REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
-REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD", "")
-
 KOREAN_WEEKDAYS = ["월", "화", "수", "목", "금", "토", "일"]
 FORUM_CHANNEL_TYPE = 15
 SCHOOL_NAME_COL = 0
+LOG_FETCH_LIMIT = 100
 
-# 채널 없음 알림 키 TTL (36시간)
-NO_CHANNEL_NOTIFIED_TTL = 36 * 60 * 60
+NO_CHANNEL_PREFIX = "[채널 없음]"
 
 
 def parse_school_schedules(rows: list[list]) -> list[dict]:
@@ -156,25 +153,24 @@ def fetch_templates() -> list[dict]:
     return [fetch_thread_template(tid) for tid in TEMPLATE_THREAD_IDS]
 
 
-def get_redis_client() -> redis.Redis:
-    return redis.Redis(
-        host=REDIS_HOST,
-        password=REDIS_PASSWORD,
-        decode_responses=True,
-    )
-
-
-def notify_missing_channel_once(
-    redis_client: redis.Redis, school_name: str, today_str: str
-) -> bool:
+def fetch_already_notified_missing(today_str: str) -> set[str]:
     """
-    채널 없음 알림을 하루 1회로 제한.
-    Returns: 알림을 새로 보냈으면 True, 이미 알린 적 있어 스킵했으면 False
+    LOG 채널의 최근 메시지를 조회하여 오늘 이미 '채널 없음' 알림이 보내진 학교 집합 반환.
+    멱등성을 Discord state로 처리하므로 외부 저장소 불필요.
     """
-    key = f"discord_notice:no_channel:{today_str}:{school_name}"
-    # SET ... NX EX ttl: 키가 없을 때만 set, 있으면 None 반환
-    was_set = redis_client.set(key, "1", nx=True, ex=NO_CHANNEL_NOTIFIED_TTL)
-    return bool(was_set)
+    if not LOG_CHANNEL_ID:
+        return set()
+    messages = get_channel_messages(LOG_CHANNEL_ID, limit=LOG_FETCH_LIMIT)
+    marker = f"{NO_CHANNEL_PREFIX} {today_str}"
+    notified = set()
+    for m in messages:
+        content = m.get("content", "")
+        if content.startswith(marker):
+            # "[채널 없음] yymmdd {학교명}-공지" → 학교명 추출
+            rest = content[len(marker) :].strip()
+            if rest.endswith("-공지"):
+                notified.add(rest[: -len("-공지")])
+    return notified
 
 
 def format_marker(end_time: datetime) -> str:
@@ -242,15 +238,15 @@ def main(dry_run: bool = False, target_date: str | None = None):
             print(f"    → {marker} - <템플릿 제목>")
         return
 
-    # 템플릿/채널/활성 스레드 한 번씩 조회
+    # 템플릿/채널/활성 스레드/이미 알린 학교 한 번씩 조회
     templates = fetch_templates()
     channels = get_guild_channels(GUILD_ID)
     active_threads = get_active_threads(GUILD_ID).get("threads", [])
 
     today_str = now.strftime("%y%m%d")
-    redis_client = get_redis_client()
+    notified_missing = fetch_already_notified_missing(today_str)
 
-    # 학교별 처리: Discord/Redis 호출의 일시적 실패가 나머지 학교 처리를 막지 않도록 격리.
+    # 학교별 처리: Discord 호출의 일시적 실패가 나머지 학교 처리를 막지 않도록 격리.
     # 다음 cron에서 멱등성으로 catch-up되지만, 실패 사실은 LOG 채널에 알려야 함.
     # 코드 버그는 잡지 않고 그대로 raise되도록 한정된 예외만 처리.
     for school_name, end_time in targets:
@@ -261,10 +257,10 @@ def main(dry_run: bool = False, target_date: str | None = None):
                 channels,
                 active_threads,
                 templates,
-                redis_client,
+                notified_missing,
                 today_str,
             )
-        except (requests.RequestException, redis.RedisError) as e:
+        except requests.RequestException as e:
             msg = f"[처리 실패] {school_name} {format_marker(end_time)}: {type(e).__name__}: {e}"
             print(f"  {msg}")
             if LOG_CHANNEL_ID:
@@ -281,7 +277,7 @@ def process_school(
     channels: list[dict],
     active_threads: list[dict],
     templates: list[dict],
-    redis_client: redis.Redis,
+    notified_missing: set[str],
     today_str: str,
 ):
     """한 학교의 공지 게시를 처리한다."""
@@ -289,10 +285,12 @@ def process_school(
     channel = find_forum_channel(channels, channel_name)
     if not channel:
         print(f"  [채널 없음] {channel_name}")
-        if LOG_CHANNEL_ID and notify_missing_channel_once(
-            redis_client, school_name, today_str
-        ):
-            create_message(LOG_CHANNEL_ID, f"[채널 없음] {channel_name}")
+        # 멱등성: LOG 채널의 오늘 알림에 이 학교가 이미 있으면 스킵
+        if LOG_CHANNEL_ID and school_name not in notified_missing:
+            create_message(
+                LOG_CHANNEL_ID, f"{NO_CHANNEL_PREFIX} {today_str} {channel_name}"
+            )
+            notified_missing.add(school_name)
         return
 
     channel_id = channel["id"]

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -17,6 +17,7 @@ import argparse
 import os
 from datetime import datetime, timedelta, timezone
 
+import redis
 from dotenv import load_dotenv
 
 from api.discord import (
@@ -48,9 +49,15 @@ TEMPLATE_THREAD_IDS = [
 ]
 LOG_CHANNEL_ID = os.environ.get("DISCORD_LOG_CHANNEL_ID", "1505927819094397038")
 
+REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
+REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD", "")
+
 KOREAN_WEEKDAYS = ["월", "화", "수", "목", "금", "토", "일"]
 FORUM_CHANNEL_TYPE = 15
 SCHOOL_NAME_COL = 0
+
+# 채널 없음 알림 키 TTL (36시간)
+NO_CHANNEL_NOTIFIED_TTL = 36 * 60 * 60
 
 
 def parse_school_schedules(rows: list[list]) -> list[dict]:
@@ -84,7 +91,8 @@ def parse_school_schedules(rows: list[list]) -> list[dict]:
             start_val = row[col + 1]
             end_val = row[col + 2]
 
-            if date_val == "":
+            # 빈 슬롯 또는 부분 입력된 슬롯은 스킵
+            if date_val == "" or start_val == "" or end_val == "":
                 col += 3
                 continue
 
@@ -136,6 +144,27 @@ def fetch_thread_template(thread_id: str) -> dict:
 def fetch_templates() -> list[dict]:
     """모든 템플릿 스레드의 제목/본문을 가져온다."""
     return [fetch_thread_template(tid) for tid in TEMPLATE_THREAD_IDS]
+
+
+def get_redis_client() -> redis.Redis:
+    return redis.Redis(
+        host=REDIS_HOST,
+        password=REDIS_PASSWORD,
+        decode_responses=True,
+    )
+
+
+def notify_missing_channel_once(
+    redis_client: redis.Redis, school_name: str, today_str: str
+) -> bool:
+    """
+    채널 없음 알림을 하루 1회로 제한.
+    Returns: 알림을 새로 보냈으면 True, 이미 알린 적 있어 스킵했으면 False
+    """
+    key = f"discord_notice:no_channel:{today_str}:{school_name}"
+    # SET ... NX EX ttl: 키가 없을 때만 set, 있으면 None 반환
+    was_set = redis_client.set(key, "1", nx=True, ex=NO_CHANNEL_NOTIFIED_TTL)
+    return bool(was_set)
 
 
 def format_marker(end_time: datetime) -> str:
@@ -208,14 +237,18 @@ def main(dry_run: bool = False, target_date: str | None = None):
     channels = get_guild_channels(GUILD_ID)
     active_threads = get_active_threads(GUILD_ID).get("threads", [])
 
+    today_str = now.strftime("%y%m%d")
+    redis_client = get_redis_client()
+
     for school_name, end_time in targets:
         channel_name = f"{school_name}-공지"
         channel = find_forum_channel(channels, channel_name)
         if not channel:
-            msg = f"[채널 없음] {channel_name}"
-            print(f"  {msg}")
-            if LOG_CHANNEL_ID:
-                create_message(LOG_CHANNEL_ID, msg)
+            print(f"  [채널 없음] {channel_name}")
+            if LOG_CHANNEL_ID and notify_missing_channel_once(
+                redis_client, school_name, today_str
+            ):
+                create_message(LOG_CHANNEL_ID, f"[채널 없음] {channel_name}")
             continue
 
         channel_id = channel["id"]

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -217,20 +217,19 @@ def main(dry_run: bool = False, target_date: str | None = None):
             continue
 
         channel_id = channel["id"]
-        marker = format_marker(end_time)
-
-        # 멱등성: 이 학교 포럼에 같은 종료시각 prefix가 붙은 스레드가 있으면 batch 전체 스킵
-        already_posted = any(
-            t.get("name", "").startswith(marker)
+        existing_titles = {
+            t.get("name", "")
             for t in active_threads
             if t.get("parent_id") == channel_id
-        )
-        if already_posted:
-            print(f"  스킵 (이미 게시됨): {channel_name} - {marker}")
-            continue
+        }
 
+        # 멱등성: 동일 제목 스레드가 이미 있으면 그 템플릿만 스킵.
+        # 부분 실패 후 재시도 시 누락분만 생성하도록 per-template 검사.
         for tmpl in templates:
             new_title = make_title(tmpl["title"], end_time)
+            if new_title in existing_titles:
+                print(f"  스킵 (중복): {new_title}")
+                continue
             create_thread(channel_id, name=new_title, content=tmpl["content"])
             print(f"  생성: {new_title}")
 

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -240,33 +240,62 @@ def main(dry_run: bool = False, target_date: str | None = None):
     today_str = now.strftime("%y%m%d")
     redis_client = get_redis_client()
 
+    # 학교별 처리: 한 학교의 외부 호출 실패가 나머지 학교 처리를 막지 않도록 격리.
+    # 다음 cron에서 멱등성으로 catch-up되지만, 실패 사실은 LOG 채널에 알려야 함.
     for school_name, end_time in targets:
-        channel_name = f"{school_name}-공지"
-        channel = find_forum_channel(channels, channel_name)
-        if not channel:
-            print(f"  [채널 없음] {channel_name}")
-            if LOG_CHANNEL_ID and notify_missing_channel_once(
-                redis_client, school_name, today_str
-            ):
-                create_message(LOG_CHANNEL_ID, f"[채널 없음] {channel_name}")
+        try:
+            process_school(
+                school_name,
+                end_time,
+                channels,
+                active_threads,
+                templates,
+                redis_client,
+                today_str,
+            )
+        except Exception as e:
+            msg = f"[처리 실패] {school_name} {format_marker(end_time)}: {type(e).__name__}: {e}"
+            print(f"  {msg}")
+            if LOG_CHANNEL_ID:
+                create_message(LOG_CHANNEL_ID, msg)
+
+
+def process_school(
+    school_name: str,
+    end_time: datetime,
+    channels: list[dict],
+    active_threads: list[dict],
+    templates: list[dict],
+    redis_client: redis.Redis,
+    today_str: str,
+):
+    """한 학교의 공지 게시를 처리한다."""
+    channel_name = f"{school_name}-공지"
+    channel = find_forum_channel(channels, channel_name)
+    if not channel:
+        print(f"  [채널 없음] {channel_name}")
+        if LOG_CHANNEL_ID and notify_missing_channel_once(
+            redis_client, school_name, today_str
+        ):
+            create_message(LOG_CHANNEL_ID, f"[채널 없음] {channel_name}")
+        return
+
+    channel_id = channel["id"]
+    existing_titles = {
+        t.get("name", "")
+        for t in active_threads
+        if t.get("parent_id") == channel_id
+    }
+
+    # 멱등성: 동일 제목 스레드가 이미 있으면 그 템플릿만 스킵.
+    # 부분 실패 후 재시도 시 누락분만 생성하도록 per-template 검사.
+    for tmpl in templates:
+        new_title = make_title(tmpl["title"], end_time)
+        if new_title in existing_titles:
+            print(f"  스킵 (중복): {new_title}")
             continue
-
-        channel_id = channel["id"]
-        existing_titles = {
-            t.get("name", "")
-            for t in active_threads
-            if t.get("parent_id") == channel_id
-        }
-
-        # 멱등성: 동일 제목 스레드가 이미 있으면 그 템플릿만 스킵.
-        # 부분 실패 후 재시도 시 누락분만 생성하도록 per-template 검사.
-        for tmpl in templates:
-            new_title = make_title(tmpl["title"], end_time)
-            if new_title in existing_titles:
-                print(f"  스킵 (중복): {new_title}")
-                continue
-            create_thread(channel_id, name=new_title, content=tmpl["content"])
-            print(f"  생성: {new_title}")
+        create_thread(channel_id, name=new_title, content=tmpl["content"])
+        print(f"  생성: {new_title}")
 
 
 if __name__ == "__main__":

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -175,7 +175,9 @@ def main(dry_run: bool = False, target_date: str | None = None):
     window_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
 
     print(f"[discord_post_completion_notice] 실행: {now.isoformat()}")
-    print(f"  윈도우: [{window_start.strftime('%Y-%m-%d %H:%M')}, {now.strftime('%H:%M')}]")
+    print(
+        f"  윈도우: [{window_start.strftime('%Y-%m-%d %H:%M')}, {now.strftime('%H:%M')}]"
+    )
 
     schools = read_school_schedules()
 

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -282,9 +282,7 @@ def process_school(
 
     channel_id = channel["id"]
     existing_titles = {
-        t.get("name", "")
-        for t in active_threads
-        if t.get("parent_id") == channel_id
+        t.get("name", "") for t in active_threads if t.get("parent_id") == channel_id
     }
 
     # 멱등성: 동일 제목 스레드가 이미 있으면 그 템플릿만 스킵.

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -48,10 +48,9 @@ TEMPLATE_THREAD_IDS = [
 ]
 LOG_CHANNEL_ID = os.environ.get("DISCORD_LOG_CHANNEL_ID", "1505927819094397038")
 
-DATE_PLACEHOLDER = "yymmdd"
+KOREAN_WEEKDAYS = ["월", "화", "수", "목", "금", "토", "일"]
 FORUM_CHANNEL_TYPE = 15
 SCHOOL_NAME_COL = 0
-WINDOW_MINUTES = 15
 
 
 def parse_school_schedules(rows: list[list]) -> list[dict]:
@@ -139,19 +138,25 @@ def fetch_templates() -> list[dict]:
     return [fetch_thread_template(tid) for tid in TEMPLATE_THREAD_IDS]
 
 
+def format_marker(end_time: datetime) -> str:
+    """종료시각을 'M.d(E) HH:mm' 형식 문자열로 포맷."""
+    weekday = KOREAN_WEEKDAYS[end_time.weekday()]
+    return f"{end_time.month}.{end_time.day}({weekday}) {end_time:%H:%M}"
+
+
 def make_title(template_title: str, end_time: datetime) -> str:
-    """템플릿 제목에서 'yymmdd' 부분을 'yymmdd_hhmm'으로 치환."""
-    marker = end_time.strftime("%y%m%d_%H%M")
-    return template_title.replace(DATE_PLACEHOLDER, marker)
+    """템플릿 제목 앞에 종료시각 prefix를 붙인다."""
+    return f"{format_marker(end_time)} - {template_title}"
 
 
 def main(dry_run: bool = False, target_date: str | None = None):
     """
-    10분마다 호출되어 윈도우 안의 종료시각을 가진 학교에 공지를 게시한다.
+    10분마다 호출되어 오늘 이미 종료된 수업의 학교에 공지를 게시한다.
+    윈도우는 오늘 자정 ~ now. 멱등성으로 중복 방지하므로 outage 후 복귀 시 자동 catch-up.
 
     Args:
         dry_run: 실제 Discord 전송 없이 콘솔 출력만
-        target_date: 테스트용 날짜 지정 (YYYY-MM-DD or MM-DD). 지정 시 하루 전체 윈도우.
+        target_date: 테스트용 날짜 지정 (YYYY-MM-DD or MM-DD). 지정 시 그 날 하루 전체를 윈도우로.
     """
     now = datetime.now(KST)
 
@@ -166,12 +171,11 @@ def main(dry_run: bool = False, target_date: str | None = None):
             print(f"  잘못된 날짜 형식: {target_date} (YYYY-MM-DD 또는 MM-DD)")
             return
         now = datetime(year, month, day, 23, 59, 59, tzinfo=KST)
-        window_start = datetime(year, month, day, 0, 0, tzinfo=KST)
-    else:
-        window_start = now - timedelta(minutes=WINDOW_MINUTES)
+
+    window_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
 
     print(f"[discord_post_completion_notice] 실행: {now.isoformat()}")
-    print(f"  윈도우: ({window_start.strftime('%H:%M')}, {now.strftime('%H:%M')}]")
+    print(f"  윈도우: [{window_start.strftime('%Y-%m-%d %H:%M')}, {now.strftime('%H:%M')}]")
 
     schools = read_school_schedules()
 
@@ -192,11 +196,9 @@ def main(dry_run: bool = False, target_date: str | None = None):
     if dry_run:
         for school_name, end_time in targets:
             channel_name = f"{school_name}-공지"
-            marker = end_time.strftime("%y%m%d_%H%M")
+            marker = format_marker(end_time)
             print(f"  [DRY-RUN] {channel_name}")
-            print(f"    → {marker}_간식증빙사진")
-            print(f"    → {marker}_출석부사진")
-            print(f"    → {marker}_수업사진")
+            print(f"    → {marker} - <템플릿 제목>")
         return
 
     # 템플릿/채널/활성 스레드 한 번씩 조회
@@ -215,17 +217,20 @@ def main(dry_run: bool = False, target_date: str | None = None):
             continue
 
         channel_id = channel["id"]
-        existing_titles = {
-            t.get("name", "")
+        marker = format_marker(end_time)
+
+        # 멱등성: 이 학교 포럼에 같은 종료시각 prefix가 붙은 스레드가 있으면 batch 전체 스킵
+        already_posted = any(
+            t.get("name", "").startswith(marker)
             for t in active_threads
             if t.get("parent_id") == channel_id
-        }
+        )
+        if already_posted:
+            print(f"  스킵 (이미 게시됨): {channel_name} - {marker}")
+            continue
 
         for tmpl in templates:
             new_title = make_title(tmpl["title"], end_time)
-            if new_title in existing_titles:
-                print(f"  스킵 (중복): {new_title}")
-                continue
             create_thread(channel_id, name=new_title, content=tmpl["content"])
             print(f"  생성: {new_title}")
 

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -19,6 +19,7 @@ import os
 from datetime import datetime, timedelta, timezone
 
 import redis
+import requests
 from dotenv import load_dotenv
 
 from api.discord import (
@@ -41,7 +42,8 @@ SHEETS_EPOCH = datetime(1899, 12, 30, tzinfo=KST)
 SPREADSHEET_ID = os.environ.get(
     "GOOGLE_SPREADSHEET_ID", "1ZP7wyxbwRO2AhyzForm7494C6bMbY_HAeNHV6-WbSnc"
 )
-WORKSHEET_ID = int(os.environ.get("GOOGLE_WORKSHEET_ID", "451387449"))
+# int 변환은 사용 시점으로 미뤄 모듈 import가 다른 잡까지 막지 않도록 함
+WORKSHEET_ID_RAW = os.environ.get("GOOGLE_WORKSHEET_ID", "451387449")
 GUILD_ID = os.environ.get("DISCORD_GUILD_ID", "1504338147155251220")
 TEMPLATE_THREAD_IDS = [
     tid.strip()
@@ -63,9 +65,14 @@ NO_CHANNEL_NOTIFIED_TTL = 36 * 60 * 60
 
 def parse_school_schedules(rows: list[list]) -> list[dict]:
     """
-    UNFORMATTED_VALUE로 읽은 시트 데이터를 학교별 일정 dict 리스트로 변환한다.
+    학교별 일정 시트 데이터를 학교별 일정 dict 리스트로 변환한다.
 
     시트 스키마: 학교명 | 날짜1 | 시작1 | 종료1 | 날짜2 | 시작2 | 종료2 | ...
+
+    Args:
+        rows: gspread `get_all_values(value_render_option="UNFORMATTED_VALUE")`로 읽은
+              데이터. 날짜 셀은 시리얼 정수, 시간 셀은 하루의 비율(float, 0.0~1.0).
+              FORMATTED_VALUE로 읽은 데이터를 넘기면 int(date_val)에서 ValueError.
 
     Returns:
         [
@@ -121,7 +128,7 @@ def parse_school_schedules(rows: list[list]) -> list[dict]:
 def read_school_schedules() -> list[dict]:
     """시트에서 학교별 일정을 읽어온다."""
     rows = get_worksheet_values(
-        SPREADSHEET_ID, WORKSHEET_ID, value_render_option="UNFORMATTED_VALUE"
+        SPREADSHEET_ID, int(WORKSHEET_ID_RAW), value_render_option="UNFORMATTED_VALUE"
     )
     return parse_school_schedules(rows)
 
@@ -243,8 +250,9 @@ def main(dry_run: bool = False, target_date: str | None = None):
     today_str = now.strftime("%y%m%d")
     redis_client = get_redis_client()
 
-    # 학교별 처리: 한 학교의 외부 호출 실패가 나머지 학교 처리를 막지 않도록 격리.
+    # 학교별 처리: Discord/Redis 호출의 일시적 실패가 나머지 학교 처리를 막지 않도록 격리.
     # 다음 cron에서 멱등성으로 catch-up되지만, 실패 사실은 LOG 채널에 알려야 함.
+    # 코드 버그는 잡지 않고 그대로 raise되도록 한정된 예외만 처리.
     for school_name, end_time in targets:
         try:
             process_school(
@@ -256,11 +264,15 @@ def main(dry_run: bool = False, target_date: str | None = None):
                 redis_client,
                 today_str,
             )
-        except Exception as e:
+        except (requests.RequestException, redis.RedisError) as e:
             msg = f"[처리 실패] {school_name} {format_marker(end_time)}: {type(e).__name__}: {e}"
             print(f"  {msg}")
             if LOG_CHANNEL_ID:
-                create_message(LOG_CHANNEL_ID, msg)
+                try:
+                    create_message(LOG_CHANNEL_ID, msg)
+                except requests.RequestException:
+                    # LOG 채널 알림 실패는 콘솔에만 남기고 진행
+                    print(f"  [LOG 알림 실패] {msg}")
 
 
 def process_school(

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -17,31 +17,31 @@ import argparse
 import os
 from datetime import datetime, timedelta, timezone
 
-from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.date import DateTrigger
 from dotenv import load_dotenv
 
 from api.discord import (
-    create_forum_thread,
-    fetch_thread_template,
+    create_message,
+    create_thread,
+    get_channel,
     get_guild_channels,
-    send_message,
+    get_message,
 )
-from api.google_sheets import read_school_schedules
+from api.google_sheets import get_worksheet_values
 
 load_dotenv()
 
 KST = timezone(timedelta(hours=9))
 TIMEZONE = "Asia/Seoul"
 
+# Google Sheets 시리얼 날짜 기준일 (1899-12-30)
+SHEETS_EPOCH = datetime(1899, 12, 30, tzinfo=KST)
+
 SPREADSHEET_ID = os.environ.get(
     "GOOGLE_SPREADSHEET_ID", "1ZP7wyxbwRO2AhyzForm7494C6bMbY_HAeNHV6-WbSnc"
 )
 WORKSHEET_ID = int(os.environ.get("GOOGLE_WORKSHEET_ID", "451387449"))
 GUILD_ID = os.environ.get("DISCORD_GUILD_ID", "1504338147155251220")
-TEMPLATE_CHANNEL_ID = os.environ.get(
-    "DISCORD_TEMPLATE_CHANNEL_ID", "1504375083546972230"
-)
 TEMPLATE_THREAD_IDS = [
     tid.strip()
     for tid in os.environ.get("DISCORD_TEMPLATE_THREAD_IDS", "").split(",")
@@ -50,8 +50,9 @@ TEMPLATE_THREAD_IDS = [
 LOG_CHANNEL_ID = os.environ.get("DISCORD_LOG_CHANNEL_ID", "1505927819094397038")
 
 DATE_PLACEHOLDER = "yymmdd"
+FORUM_CHANNEL_TYPE = 15
+SCHOOL_NAME_COL = 0
 
-# 모듈 레벨 스케줄러 참조 (scheduler.py에서 주입)
 _scheduler = None
 
 
@@ -61,13 +62,92 @@ def set_scheduler(scheduler):
     _scheduler = scheduler
 
 
-def _fetch_templates() -> list[dict]:
-    """템플릿 스레드들을 fetch하여 제목/본문을 가져온다."""
-    templates = []
-    for thread_id in TEMPLATE_THREAD_IDS:
-        tmpl = fetch_thread_template(thread_id)
-        templates.append(tmpl)
-    return templates
+def parse_school_schedules(rows: list[list]) -> list[dict]:
+    """
+    UNFORMATTED_VALUE로 읽은 시트 데이터를 학교별 일정 dict 리스트로 변환한다.
+
+    시트 스키마: 학교명 | 날짜1 | 시작1 | 종료1 | 날짜2 | 시작2 | 종료2 | ...
+
+    Returns:
+        [
+            {
+                "school_name": "선인고등학교",
+                "schedules": [
+                    {"date": datetime, "start_hour": 13, "start_min": 30, "end_hour": 17, "end_min": 30},
+                    ...
+                ]
+            },
+            ...
+        ]
+    """
+    results = []
+    for row in rows[1:]:  # 헤더 스킵
+        school_name = str(row[SCHOOL_NAME_COL]).strip() if row else ""
+        if not school_name:
+            continue
+
+        schedules = []
+        col = 1
+        while col + 2 < len(row):
+            date_val = row[col]
+            start_val = row[col + 1]
+            end_val = row[col + 2]
+
+            # 빈 슬롯 (학교당 최대 12슬롯 중 미사용)
+            if date_val == "":
+                col += 3
+                continue
+
+            date = SHEETS_EPOCH + timedelta(days=int(date_val))
+            start_minutes = round(start_val * 1440)
+            end_minutes = round(end_val * 1440)
+
+            schedules.append({
+                "date": date,
+                "start_hour": start_minutes // 60,
+                "start_min": start_minutes % 60,
+                "end_hour": end_minutes // 60,
+                "end_min": end_minutes % 60,
+            })
+
+            col += 3
+
+        results.append({"school_name": school_name, "schedules": schedules})
+
+    return results
+
+
+def read_school_schedules() -> list[dict]:
+    """시트에서 학교별 일정을 읽어온다."""
+    rows = get_worksheet_values(SPREADSHEET_ID, WORKSHEET_ID)
+    return parse_school_schedules(rows)
+
+
+def find_forum_channel(guild_id: str, channel_name: str) -> dict | None:
+    """서버에서 이름이 일치하는 포럼 채널을 찾는다."""
+    channels = get_guild_channels(guild_id)
+    for ch in channels:
+        if ch.get("type") == FORUM_CHANNEL_TYPE and ch.get("name") == channel_name:
+            return ch
+    return None
+
+
+def fetch_thread_template(thread_id: str) -> dict:
+    """
+    포럼 스레드의 제목과 시작 메시지 본문을 가져온다.
+    포럼 스레드의 시작 메시지는 id가 thread_id와 동일하다.
+
+    Returns:
+        {"title": "yymmdd_간식증빙사진", "content": "-"}
+    """
+    channel = get_channel(thread_id)
+    starter = get_message(thread_id, thread_id)
+    return {"title": channel["name"], "content": starter["content"]}
+
+
+def fetch_templates() -> list[dict]:
+    """모든 템플릿 스레드의 제목/본문을 가져온다."""
+    return [fetch_thread_template(tid) for tid in TEMPLATE_THREAD_IDS]
 
 
 def post_notice(school_name: str, date_str: str):
@@ -82,23 +162,19 @@ def post_notice(school_name: str, date_str: str):
     channel_name = f"{school_name}-공지"
     print(f"[post_notice] {channel_name} 공지 시작")
 
-    channels = get_guild_channels(GUILD_ID)
-    forum_channels = {ch["name"]: ch for ch in channels if ch.get("type") == 15}
-
-    channel = forum_channels.get(channel_name)
+    channel = find_forum_channel(GUILD_ID, channel_name)
     if not channel:
         msg = f"[채널 없음] {channel_name}"
         print(f"  {msg}")
         if LOG_CHANNEL_ID:
-            send_message(LOG_CHANNEL_ID, msg)
+            create_message(LOG_CHANNEL_ID, msg)
         return
 
-    channel_id = channel["id"]
-    templates = _fetch_templates()
+    templates = fetch_templates()
 
     for tmpl in templates:
         new_title = tmpl["title"].replace(DATE_PLACEHOLDER, date_str)
-        create_forum_thread(channel_id, title=new_title, content=tmpl["content"])
+        create_thread(channel["id"], name=new_title, content=tmpl["content"])
         print(f"  게시물 생성: {new_title}")
 
     print(f"[post_notice] {channel_name} 공지 완료")
@@ -120,7 +196,7 @@ def schedule_today_notices(scheduler=None):
 
     print(f"[schedule_today_notices] {today} 일정 등록 시작")
 
-    schools = read_school_schedules(SPREADSHEET_ID, WORKSHEET_ID)
+    schools = read_school_schedules()
     registered = 0
 
     for school in schools:
@@ -172,10 +248,9 @@ def main(dry_run: bool = False, target_date: str | None = None):
 
     print(f"[discord_post_completion_notice] 실행: {target}")
 
-    schools = read_school_schedules(SPREADSHEET_ID, WORKSHEET_ID)
+    schools = read_school_schedules()
     print(f"  학교 수: {len(schools)}")
 
-    # 해당 날짜에 수업이 있는 학교 찾기
     notices = []
     for school in schools:
         for s in school["schedules"]:
@@ -197,8 +272,7 @@ def main(dry_run: bool = False, target_date: str | None = None):
             print(f"    → {today_str}_수업사진")
         return
 
-    # 실제 실행 (--date로 수동 트리거)
-    for school_name, end_time in notices:
+    for school_name, _ in notices:
         post_notice(school_name, today_str)
 
 

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -3,9 +3,10 @@
 
 10분마다 실행되며:
 1. Google Sheets에서 학교별 수업 일정을 읽음
-2. (now - 15분, now] 윈도우에 종료시각이 들어가는 학교를 감지 (10분 주기 + 5분 여유)
+2. 오늘 자정 ~ now 윈도우에 종료시각이 들어가는 학교를 감지
+   (outage 후 복귀 시 그날 안이면 자동 catch-up)
 3. "{학교이름}-공지" 포럼 채널에 템플릿 기반 게시물 3개 작성
-4. 멱등성: 같은 제목의 활성 스레드가 이미 있으면 스킵
+4. 멱등성: 같은 제목의 활성 스레드가 이미 있으면 그 템플릿만 스킵 (per-template)
 """
 
 import sys
@@ -119,7 +120,9 @@ def parse_school_schedules(rows: list[list]) -> list[dict]:
 
 def read_school_schedules() -> list[dict]:
     """시트에서 학교별 일정을 읽어온다."""
-    rows = get_worksheet_values(SPREADSHEET_ID, WORKSHEET_ID)
+    rows = get_worksheet_values(
+        SPREADSHEET_ID, WORKSHEET_ID, value_render_option="UNFORMATTED_VALUE"
+    )
     return parse_school_schedules(rows)
 
 

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -1,11 +1,11 @@
 """
 수업 종료 후 Discord 포럼 채널에 자동 공지 게시
 
-두 단계로 동작:
-1. schedule_today_notices(): 매일 아침 크론으로 실행.
-   Google Sheets에서 오늘 일정을 읽고, 각 종료시각에 맞춰 APScheduler 1회성 job 등록.
-2. post_notice(): 등록된 종료시각에 실행.
-   해당 학교의 "{학교이름}-공지" 포럼 채널에 템플릿 기반 게시물 3개 작성.
+10분마다 실행되며:
+1. Google Sheets에서 학교별 수업 일정을 읽음
+2. (now - 15분, now] 윈도우에 종료시각이 들어가는 학교를 감지 (10분 주기 + 5분 여유)
+3. "{학교이름}-공지" 포럼 채널에 템플릿 기반 게시물 3개 작성
+4. 멱등성: 같은 제목의 활성 스레드가 이미 있으면 스킵
 """
 
 import sys
@@ -17,12 +17,12 @@ import argparse
 import os
 from datetime import datetime, timedelta, timezone
 
-from apscheduler.triggers.date import DateTrigger
 from dotenv import load_dotenv
 
 from api.discord import (
     create_message,
     create_thread,
+    get_active_threads,
     get_channel,
     get_guild_channels,
     get_message,
@@ -32,7 +32,6 @@ from api.google_sheets import get_worksheet_values
 load_dotenv()
 
 KST = timezone(timedelta(hours=9))
-TIMEZONE = "Asia/Seoul"
 
 # Google Sheets 시리얼 날짜 기준일 (1899-12-30)
 SHEETS_EPOCH = datetime(1899, 12, 30, tzinfo=KST)
@@ -52,14 +51,7 @@ LOG_CHANNEL_ID = os.environ.get("DISCORD_LOG_CHANNEL_ID", "1505927819094397038")
 DATE_PLACEHOLDER = "yymmdd"
 FORUM_CHANNEL_TYPE = 15
 SCHOOL_NAME_COL = 0
-
-_scheduler = None
-
-
-def set_scheduler(scheduler):
-    """외부 스케줄러 인스턴스를 주입받는다."""
-    global _scheduler
-    _scheduler = scheduler
+WINDOW_MINUTES = 15
 
 
 def parse_school_schedules(rows: list[list]) -> list[dict]:
@@ -81,7 +73,7 @@ def parse_school_schedules(rows: list[list]) -> list[dict]:
         ]
     """
     results = []
-    for row in rows[1:]:  # 헤더 스킵
+    for row in rows[1:]:
         school_name = str(row[SCHOOL_NAME_COL]).strip() if row else ""
         if not school_name:
             continue
@@ -93,7 +85,6 @@ def parse_school_schedules(rows: list[list]) -> list[dict]:
             start_val = row[col + 1]
             end_val = row[col + 2]
 
-            # 빈 슬롯 (학교당 최대 12슬롯 중 미사용)
             if date_val == "":
                 col += 3
                 continue
@@ -125,9 +116,8 @@ def read_school_schedules() -> list[dict]:
     return parse_school_schedules(rows)
 
 
-def find_forum_channel(guild_id: str, channel_name: str) -> dict | None:
-    """서버에서 이름이 일치하는 포럼 채널을 찾는다."""
-    channels = get_guild_channels(guild_id)
+def find_forum_channel(channels: list[dict], channel_name: str) -> dict | None:
+    """채널 목록에서 이름이 일치하는 포럼 채널을 찾는다."""
     for ch in channels:
         if ch.get("type") == FORUM_CHANNEL_TYPE and ch.get("name") == channel_name:
             return ch
@@ -138,9 +128,6 @@ def fetch_thread_template(thread_id: str) -> dict:
     """
     포럼 스레드의 제목과 시작 메시지 본문을 가져온다.
     포럼 스레드의 시작 메시지는 id가 thread_id와 동일하다.
-
-    Returns:
-        {"title": "yymmdd_간식증빙사진", "content": "-"}
     """
     channel = get_channel(thread_id)
     starter = get_message(thread_id, thread_id)
@@ -152,84 +139,20 @@ def fetch_templates() -> list[dict]:
     return [fetch_thread_template(tid) for tid in TEMPLATE_THREAD_IDS]
 
 
-def post_notice(school_name: str, date_str: str):
-    """
-    특정 학교의 포럼 채널에 공지 게시물 3개를 작성한다.
-    APScheduler에 의해 종료시각에 호출된다.
-
-    Args:
-        school_name: 학교명
-        date_str: 날짜 문자열 (예: "260531")
-    """
-    channel_name = f"{school_name}-공지"
-    print(f"[post_notice] {channel_name} 공지 시작")
-
-    channel = find_forum_channel(GUILD_ID, channel_name)
-    if not channel:
-        msg = f"[채널 없음] {channel_name}"
-        print(f"  {msg}")
-        if LOG_CHANNEL_ID:
-            create_message(LOG_CHANNEL_ID, msg)
-        return
-
-    templates = fetch_templates()
-
-    for tmpl in templates:
-        new_title = tmpl["title"].replace(DATE_PLACEHOLDER, date_str)
-        create_thread(channel["id"], name=new_title, content=tmpl["content"])
-        print(f"  게시물 생성: {new_title}")
-
-    print(f"[post_notice] {channel_name} 공지 완료")
-
-
-def schedule_today_notices(scheduler=None):
-    """
-    오늘 수업이 있는 학교를 찾아 종료시각에 맞춰 1회성 job을 등록한다.
-    매일 아침 크론으로 호출된다.
-    """
-    sched = scheduler or _scheduler
-    if not sched:
-        print("[schedule_today_notices] 스케줄러가 없습니다.")
-        return
-
-    now = datetime.now(KST)
-    today = now.date()
-    today_str = now.strftime("%y%m%d")
-
-    print(f"[schedule_today_notices] {today} 일정 등록 시작")
-
-    schools = read_school_schedules()
-    registered = 0
-
-    for school in schools:
-        for s in school["schedules"]:
-            if s["date"].date() != today:
-                continue
-
-            end_time = s["date"].replace(hour=s["end_hour"], minute=s["end_min"])
-
-            # 이미 지난 시각은 스킵
-            if end_time <= now:
-                continue
-
-            job_id = f"discord_notice_{school['school_name']}_{today_str}_{s['end_hour']:02d}{s['end_min']:02d}"
-
-            sched.add_job(
-                post_notice,
-                trigger=DateTrigger(run_date=end_time, timezone=TIMEZONE),
-                id=job_id,
-                name=job_id,
-                args=[school["school_name"], today_str],
-                replace_existing=True,
-            )
-            print(f"  등록: {school['school_name']} → {end_time.strftime('%H:%M')}")
-            registered += 1
-
-    print(f"[schedule_today_notices] {registered}개 job 등록 완료")
+def make_title(template_title: str, end_time: datetime) -> str:
+    """템플릿 제목에서 'yymmdd' 부분을 'yymmdd_hhmm'으로 치환."""
+    marker = end_time.strftime("%y%m%d_%H%M")
+    return template_title.replace(DATE_PLACEHOLDER, marker)
 
 
 def main(dry_run: bool = False, target_date: str | None = None):
-    """CLI용 엔트리포인트. dry-run 및 날짜 지정 테스트 지원."""
+    """
+    10분마다 호출되어 윈도우 안의 종료시각을 가진 학교에 공지를 게시한다.
+
+    Args:
+        dry_run: 실제 Discord 전송 없이 콘솔 출력만
+        target_date: 테스트용 날짜 지정 (YYYY-MM-DD or MM-DD). 지정 시 하루 전체 윈도우.
+    """
     now = datetime.now(KST)
 
     if target_date:
@@ -242,40 +165,69 @@ def main(dry_run: bool = False, target_date: str | None = None):
         else:
             print(f"  잘못된 날짜 형식: {target_date} (YYYY-MM-DD 또는 MM-DD)")
             return
-        target = datetime(year, month, day, tzinfo=KST).date()
+        now = datetime(year, month, day, 23, 59, 59, tzinfo=KST)
+        window_start = datetime(year, month, day, 0, 0, tzinfo=KST)
     else:
-        target = now.date()
+        window_start = now - timedelta(minutes=WINDOW_MINUTES)
 
-    today_str = target.strftime("%y%m%d")
-
-    print(f"[discord_post_completion_notice] 실행: {target}")
+    print(f"[discord_post_completion_notice] 실행: {now.isoformat()}")
+    print(f"  윈도우: ({window_start.strftime('%H:%M')}, {now.strftime('%H:%M')}]")
 
     schools = read_school_schedules()
-    print(f"  학교 수: {len(schools)}")
 
-    notices = []
+    # 윈도우 안에 종료시각이 들어가는 (학교, end_time) 추출
+    targets = []
     for school in schools:
         for s in school["schedules"]:
-            if s["date"].date() != target:
-                continue
             end_time = s["date"].replace(hour=s["end_hour"], minute=s["end_min"])
-            notices.append((school["school_name"], end_time))
+            if window_start < end_time <= now:
+                targets.append((school["school_name"], end_time))
 
-    if not notices:
-        print("  공지 대상 학교 없음")
+    if not targets:
+        print("  공지 대상 없음")
         return
+
+    print(f"  대상 {len(targets)}건")
 
     if dry_run:
-        for school_name, end_time in notices:
+        for school_name, end_time in targets:
             channel_name = f"{school_name}-공지"
-            print(f"  [DRY-RUN] {end_time.strftime('%H:%M')} → {channel_name}")
-            print(f"    → {today_str}_간식증빙사진")
-            print(f"    → {today_str}_출석부사진")
-            print(f"    → {today_str}_수업사진")
+            marker = end_time.strftime("%y%m%d_%H%M")
+            print(f"  [DRY-RUN] {channel_name}")
+            print(f"    → {marker}_간식증빙사진")
+            print(f"    → {marker}_출석부사진")
+            print(f"    → {marker}_수업사진")
         return
 
-    for school_name, _ in notices:
-        post_notice(school_name, today_str)
+    # 템플릿/채널/활성 스레드 한 번씩 조회
+    templates = fetch_templates()
+    channels = get_guild_channels(GUILD_ID)
+    active_threads = get_active_threads(GUILD_ID).get("threads", [])
+
+    for school_name, end_time in targets:
+        channel_name = f"{school_name}-공지"
+        channel = find_forum_channel(channels, channel_name)
+        if not channel:
+            msg = f"[채널 없음] {channel_name}"
+            print(f"  {msg}")
+            if LOG_CHANNEL_ID:
+                create_message(LOG_CHANNEL_ID, msg)
+            continue
+
+        channel_id = channel["id"]
+        existing_titles = {
+            t.get("name", "")
+            for t in active_threads
+            if t.get("parent_id") == channel_id
+        }
+
+        for tmpl in templates:
+            new_title = make_title(tmpl["title"], end_time)
+            if new_title in existing_titles:
+                print(f"  스킵 (중복): {new_title}")
+                continue
+            create_thread(channel_id, name=new_title, content=tmpl["content"])
+            print(f"  생성: {new_title}")
 
 
 if __name__ == "__main__":

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -39,7 +39,9 @@ SPREADSHEET_ID = os.environ.get(
 )
 WORKSHEET_ID = int(os.environ.get("GOOGLE_WORKSHEET_ID", "451387449"))
 GUILD_ID = os.environ.get("DISCORD_GUILD_ID", "1504338147155251220")
-TEMPLATE_CHANNEL_ID = os.environ.get("DISCORD_TEMPLATE_CHANNEL_ID", "1504375083546972230")
+TEMPLATE_CHANNEL_ID = os.environ.get(
+    "DISCORD_TEMPLATE_CHANNEL_ID", "1504375083546972230"
+)
 TEMPLATE_THREAD_IDS = [
     tid.strip()
     for tid in os.environ.get("DISCORD_TEMPLATE_THREAD_IDS", "").split(",")
@@ -202,7 +204,9 @@ def main(dry_run: bool = False, target_date: str | None = None):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="수업 종료 후 Discord 공지 자동 게시")
-    parser.add_argument("--dry-run", action="store_true", help="실제 전송 없이 콘솔 출력만")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="실제 전송 없이 콘솔 출력만"
+    )
     parser.add_argument("--date", type=str, help="대상 날짜 (YYYY-MM-DD 또는 MM-DD)")
     args = parser.parse_args()
     main(dry_run=args.dry_run, target_date=args.date)

--- a/scripts/discord_post_completion_notice.py
+++ b/scripts/discord_post_completion_notice.py
@@ -102,13 +102,15 @@ def parse_school_schedules(rows: list[list]) -> list[dict]:
             start_minutes = round(start_val * 1440)
             end_minutes = round(end_val * 1440)
 
-            schedules.append({
-                "date": date,
-                "start_hour": start_minutes // 60,
-                "start_min": start_minutes % 60,
-                "end_hour": end_minutes // 60,
-                "end_min": end_minutes % 60,
-            })
+            schedules.append(
+                {
+                    "date": date,
+                    "start_hour": start_minutes // 60,
+                    "start_min": start_minutes % 60,
+                    "end_hour": end_minutes // 60,
+                    "end_min": end_minutes % 60,
+                }
+            )
 
             col += 3
 


### PR DESCRIPTION
# 요구 사항

운영팀 연수 사업에서 학교별 수업이 종료되면 해당 학교의 Discord 포럼 채널에 자동으로 공지 게시물을 작성한다.

- Notion: INF-192 [운영팀] 디스코드 서버 봇 (연수 사업)

# 변경 사항

## 신규 모듈
- `api/google_sheets.py` — Google Sheets API 래퍼. `UNFORMATTED_VALUE`로 읽어 시리얼 숫자를 datetime으로 변환.
- `api/discord.py` — Discord API 래퍼. 채널/스레드 조회, 포럼 스레드 생성, 템플릿 메시지 fetch.
- `scripts/discord_post_completion_notice.py` — 메인 스크립트.
  - `schedule_today_notices()`: 매일 07:00 크론으로 오늘 일정 조회 → APScheduler 1회성 job 동적 등록
  - `post_notice()`: 종료시각에 호출되어 "{학교명}-공지" 포럼에 게시물 3개 작성 (간식증빙/출석부/수업사진)
  - CLI: `--dry-run`, `--date YYYY-MM-DD` 로 로컬 테스트 지원

## 기존 파일 수정
- `scheduler.py` — `set_scheduler()` 패턴으로 동적 잡 등록 모듈에 스케줄러 인스턴스 자동 주입.
- `config.yaml` — `discord_schedule_today_notices` 잡 등록 (매일 07:00).
- `requirements.txt` — `gspread`, `google-auth` 추가.
- `.env.example` — Discord/Google Sheets 환경 변수 항목 추가.

## 동작 방식
1. **데이터 소스**: 구글 시트 "학교 수요조사_자동봇" 탭 (학교명 + 날짜/시작/종료 컬럼 반복 구조).
2. **트리거**: 매일 07:00에 그날 종료시각을 모두 읽어 APScheduler에 1회성 job으로 등록.
3. **실행**: 등록된 종료시각이 되면 해당 학교 포럼 채널에 템플릿 3개를 그대로 복제한 게시물 생성.
4. **에러 처리**: 채널이 없으면 로그 채널에 알림.

# 기타

- 템플릿 게시물의 제목/본문은 Discord에서 직접 수정 가능 (코드 수정 불필요).
- 당일 일정 변경 시에는 다음날에 반영됨.