### PR TITLE
fix: add timeout to Redash API calls

### DIFF
--- a/api/redash.py
+++ b/api/redash.py
@@ -51,7 +51,7 @@ def list_dashboards(query: str | None = None) -> dict:
     if query:
         params["q"] = query
 
-    response = requests.get(url, headers=get_headers(), params=params)
+    response = requests.get(url, headers=get_headers(), params=params, timeout=30)
     response.raise_for_status()
     return response.json()
 
@@ -67,7 +67,7 @@ def get_dashboard(dashboard_slug: str) -> dict:
         dict: 대시보드 상세 정보 (원본 Redash 응답)
     """
     url = f"{get_base_url()}/api/dashboards/{dashboard_slug}"
-    response = requests.get(url, headers=get_headers())
+    response = requests.get(url, headers=get_headers(), timeout=30)
     response.raise_for_status()
     return response.json()
 
@@ -83,7 +83,7 @@ def get_query(query_id: int) -> dict:
         dict: 쿼리 상세 정보 (원본 Redash 응답)
     """
     url = f"{get_base_url()}/api/queries/{query_id}"
-    response = requests.get(url, headers=get_headers())
+    response = requests.get(url, headers=get_headers(), timeout=30)
     response.raise_for_status()
     return response.json()
 
@@ -102,6 +102,6 @@ def search_queries(query: str, page: int = 1, page_size: int = 25) -> dict:
     """
     url = f"{get_base_url()}/api/queries"
     params = {"q": query, "page": page, "page_size": page_size}
-    response = requests.get(url, headers=get_headers(), params=params)
+    response = requests.get(url, headers=get_headers(), params=params, timeout=30)
     response.raise_for_status()
     return response.json()


### PR DESCRIPTION
## Summary
- `api/redash.py`의 모든 `requests.get()` 호출에 `timeout=30` 추가
- 데이터봇이 특정 Redash 쿼리 조회 시 무한 대기하는 현상 방지

## Context
데이터봇 채널에서 `read_redash_query({'query_id': 526})` 호출 시 반복적으로 hang 발생.
Redash 서버 응답이 느릴 경우 timeout 없이 무한 대기하던 문제.

Slack: https://monolith-keb2010.slack.com/archives/C0AHU2XDBT2/p1779452607646969
Notion: https://www.notion.so/team-mono/3681cc820da6814e86b1edf90e678e5c

## Test plan
- [ ] 정상 Redash 쿼리 조회가 timeout 내에 완료되는지 확인
- [ ] timeout 초과 시 에러가 적절히 발생하는지 확인 (기존 try/except에서 처리됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)