### PR TITLE
fix: 데이터봇 hang 방지 - ChatOpenAI timeout + ToolStatusHandler Lock 에러 수정

### DIFF
--- a/app/data_bot.py
+++ b/app/data_bot.py
@@ -2,6 +2,7 @@
 데이터 봇 전용 로직
 """
 
+import asyncio
 from datetime import datetime
 
 from langchain_core.messages import BaseMessage, SystemMessage, HumanMessage
@@ -206,6 +207,7 @@ async def answer_data_analysis(
         temperature=0,
         reasoning=reasoning,
         output_version="responses/v1",
+        request_timeout=300,  # OpenAI API hang 시 5분 후 타임아웃
     )
 
     # 데이터 분석 전용 Tools
@@ -232,10 +234,20 @@ async def answer_data_analysis(
         say=say, thread_ts=thread_ts, slack_client=slack_client, channel=channel
     )
 
-    response = await agent_executor.ainvoke(
-        {"messages": messages},
-        {"callbacks": [tool_status_handler], "recursion_limit": 200},
-    )
+    try:
+        response = await asyncio.wait_for(
+            agent_executor.ainvoke(
+                {"messages": messages},
+                {"callbacks": [tool_status_handler], "recursion_limit": 200},
+            ),
+            timeout=600,  # 에이전트 전체 실행 10분 타임아웃
+        )
+    except asyncio.TimeoutError:
+        await say(
+            "⚠️ 에이전트 실행이 10분을 초과하여 중단되었습니다. 질문을 더 구체적으로 작성하거나 다시 시도해 주세요.",
+            thread_ts=thread_ts,
+        )
+        return
 
     # GPT-5.2 reasoning 모드에서는 content가 리스트로 반환될 수 있음
     # [{'type': 'reasoning', ...}, {'type': 'text', 'text': '실제 응답', ...}]

--- a/app/tool_status_handler.py
+++ b/app/tool_status_handler.py
@@ -4,10 +4,10 @@
 
 import asyncio
 import os
-from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.callbacks import AsyncCallbackHandler
 
 
-class ToolStatusHandler(BaseCallbackHandler):
+class ToolStatusHandler(AsyncCallbackHandler):
     """
     Agent 툴 호출 상태를 Slack에 표시하는 핸들러
 
@@ -35,15 +35,8 @@ class ToolStatusHandler(BaseCallbackHandler):
         self.tool_history = (
             []
         )  # 실행된 툴 이력: {"run_id": str, "name": str, "params": str, "status": str}
-        self._lock = None  # 동시성 제어를 위한 lock (lazy init)
+        self._lock = asyncio.Lock()  # 동시성 제어를 위한 lock
         self.langsmith_run_id = None  # LangSmith trace의 최상위 run_id
-
-    @property
-    def lock(self):
-        """현재 event loop에서 Lock을 lazy하게 생성"""
-        if self._lock is None:
-            self._lock = asyncio.Lock()
-        return self._lock
 
     def _format_status_text(self) -> str:
         """
@@ -140,7 +133,7 @@ class ToolStatusHandler(BaseCallbackHandler):
         tool_name = serialized["name"]
         run_id = kwargs.get("run_id")  # 툴 실행의 고유 ID
 
-        async with self.lock:
+        async with self._lock:
             self.tool_history.append(
                 {
                     "run_id": run_id,
@@ -190,7 +183,7 @@ class ToolStatusHandler(BaseCallbackHandler):
         run_id = kwargs.get("run_id")  # 완료된 툴의 고유 ID
 
         # Lock 안에서는 tool_history만 수정
-        async with self.lock:
+        async with self._lock:
             # run_id로 정확한 툴을 찾아 완료 상태로 변경
             for tool_info in self.tool_history:
                 if tool_info["run_id"] == run_id:
@@ -229,7 +222,7 @@ class ToolStatusHandler(BaseCallbackHandler):
         run_id = kwargs.get("run_id")  # 에러가 발생한 툴의 고유 ID
 
         # Lock 안에서는 tool_history만 수정
-        async with self.lock:
+        async with self._lock:
             # run_id로 정확한 툴을 찾아 에러 상태로 변경
             for tool_info in self.tool_history:
                 if tool_info["run_id"] == run_id:


### PR DESCRIPTION
## Summary

데이터봇이 특정 Redash 대시보드 쿼리 시 무한 hang되는 문제를 수정합니다.

**근본 원인 분석:**
- `ChatOpenAI`에 `request_timeout` 미설정 → OpenAI API가 응답하지 않으면 무한 대기
- 로그 분석 결과: 도구 실행은 정상 완료되나 LLM 2차 호출(최종 답변 생성)에서 50분+ hang
- `ToolStatusHandler`가 `BaseCallbackHandler`를 사용하여 async 콜백이 다른 이벤트 루프에서 실행 → `asyncio.Lock` 바인딩 에러

**수정 내용:**
- `ChatOpenAI`에 `request_timeout=300` 추가 (OpenAI HTTP 요청 5분 타임아웃)
- `agent_executor.ainvoke()`를 `asyncio.wait_for(timeout=600)`으로 래핑 (에이전트 전체 실행 10분 타임아웃, 타임아웃 시 사용자에게 안내 메시지)
- `ToolStatusHandler`를 `AsyncCallbackHandler`로 변경하여 올바른 이벤트 루프에서 콜백 실행
- `asyncio.Lock` lazy init 제거, `__init__`에서 직접 초기화

## Test plan

- [ ] 데이터봇 멘션 후 정상 응답 확인
- [ ] `asyncio.locks.Lock is bound to a different event loop` 에러 미발생 확인
- [ ] 도구 상태 표시(⏳→✅) 정상 동작 확인

Slack 요청: https://monolith-keb2010.slack.com/archives/C0AHU2XDBT2/p1779452607646969
Notion: https://www.notion.so/team-mono/3681cc820da68153bdb7d5ede7557fae

🤖 Generated with [Claude Code](https://claude.com/claude-code)