### PR TITLE
fix: active_projects KeyError 방지

### DIFF
--- a/app/common.py
+++ b/app/common.py
@@ -413,9 +413,12 @@ def get_create_notion_task_tool(
         if component and component_options:
             properties["구성요소"] = {"multi_select": [{"name": component}]}
         if project and active_projects:
-            project_id = active_projects.get(project)
-            if project_id:
-                properties["프로젝트"] = {"relation": [{"id": project_id}]}
+            if project not in active_projects:
+                raise ValueError(
+                    f"'{project}'는 유효하지 않은 프로젝트명입니다. "
+                    f"가능한 값: {', '.join(active_projects.keys())}"
+                )
+            properties["프로젝트"] = {"relation": [{"id": active_projects[project]}]}
 
         if notion_assignee_id:
             properties["담당자"] = {"people": [{"id": notion_assignee_id}]}

--- a/app/common.py
+++ b/app/common.py
@@ -413,7 +413,9 @@ def get_create_notion_task_tool(
         if component and component_options:
             properties["구성요소"] = {"multi_select": [{"name": component}]}
         if project and active_projects:
-            properties["프로젝트"] = {"relation": [{"id": active_projects[project]}]}
+            project_id = active_projects.get(project)
+            if project_id:
+                properties["프로젝트"] = {"relation": [{"id": project_id}]}
 
         if notion_assignee_id:
             properties["담당자"] = {"people": [{"id": notion_assignee_id}]}


### PR DESCRIPTION
## Summary
- `create_notion_task`에서 LLM이 `active_projects` 딕셔너리에 없는 프로젝트명을 생성할 때 `KeyError` 발생하는 문제 수정
- 무효한 프로젝트명에 대해 `ValueError`를 raise하여 LangGraph agent가 에러를 받고 유효한 프로젝트명으로 재시도하도록 변경
- LangGraph의 `ToolNode`는 기본적으로 `handle_tool_errors=True`이므로 예외가 agent에게 피드백됨

## Context
- Sentry: [WORKFLOW-AUTOMATION-5K](https://team-monolith.sentry.io/issues/WORKFLOW-AUTOMATION-5K), [WORKFLOW-AUTOMATION-5J](https://team-monolith.sentry.io/issues/WORKFLOW-AUTOMATION-5J)
- LLM이 enum 제약에도 불구하고 `'26Y 디지털 새싹'`이라는 존재하지 않는 프로젝트명을 생성하여 발생
- Notion: https://www.notion.so/team-mono/36e1cc820da681778cd1fc5bec1d70ee

## Test plan
- [x] `py_compile` 문법 검증 통과
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)