### PR TITLE
feat: create_notion_task 도구에 target_database 선택 기능 추가

### DIFF
--- a/app/common.py
+++ b/app/common.py
@@ -295,6 +295,8 @@ def get_create_notion_task_tool(
     client,
     project_data_source_id: str | None = None,
     title_property_name: str = "제목",
+    all_databases: dict[str, dict[str, str]] | None = None,
+    default_db_name: str | None = None,
 ):
     """노션 작업 생성 도구를 반환합니다.
 
@@ -383,6 +385,23 @@ def get_create_notion_task_tool(
         ),
     )
 
+    if all_databases and len(all_databases) > 1:
+        db_names = list(all_databases.keys())
+        default_label = default_db_name or "main"
+        fields["target_database"] = (
+            str | None,
+            Field(
+                default=None,
+                description=(
+                    f"작업을 생성할 대상 데이터베이스. "
+                    f"지정하지 않으면 사용자의 기본 DB({default_label})를 사용합니다. "
+                    f"사용자가 '인프라 과업', 'INF 티커' 등 특정 DB를 지정하면 해당 DB를 선택하세요. "
+                    f"가능한 값: {', '.join(db_names)}"
+                ),
+                json_schema_extra={"enum": db_names},
+            ),
+        )
+
     CreateNotionTaskInput = create_model("CreateNotionTaskInput", **fields)
 
     @tool("create_notion_task", args_schema=CreateNotionTaskInput)
@@ -392,6 +411,7 @@ def get_create_notion_task_tool(
         component: str | None = None,
         project: str | None = None,
         blocks: str | None = None,
+        target_database: str | None = None,
     ) -> str:
         """
         노션에 새로운 작업 페이지를 생성합니다.
@@ -401,24 +421,36 @@ def get_create_notion_task_tool(
         Returns:
             생성된 노션 페이지의 URL
         """
+        # 대상 DB 결정: target_database가 지정되면 해당 DB 사용
+        if target_database and all_databases and target_database in all_databases:
+            actual_ds_id = all_databases[target_database]["data_source_id"]
+            actual_title_prop = all_databases[target_database]["title_property"]
+            is_override = target_database != default_db_name
+        else:
+            actual_ds_id = data_source_id
+            actual_title_prop = title_property_name
+            is_override = False
+
         notion_assignee_id = await get_assignee_id()
 
         properties = {
-            title_property_name: {"title": [{"text": {"content": title}}]},
+            actual_title_prop: {"title": [{"text": {"content": title}}]},
             "상태": {"status": {"name": "대기"}},
         }
 
-        if task_type and task_type_options:
-            properties["유형"] = {"select": {"name": task_type}}
-        if component and component_options:
-            properties["구성요소"] = {"multi_select": [{"name": component}]}
-        if project and active_projects:
-            if project not in active_projects:
-                raise ValueError(
-                    f"'{project}'는 유효하지 않은 프로젝트명입니다. "
-                    f"가능한 값: {', '.join(active_projects.keys())}"
-                )
-            properties["프로젝트"] = {"relation": [{"id": active_projects[project]}]}
+        # DB를 오버라이드한 경우, 기본 DB 전용 속성(유형/구성요소/프로젝트)은 건너뜀
+        if not is_override:
+            if task_type and task_type_options:
+                properties["유형"] = {"select": {"name": task_type}}
+            if component and component_options:
+                properties["구성요소"] = {"multi_select": [{"name": component}]}
+            if project and active_projects:
+                if project not in active_projects:
+                    raise ValueError(
+                        f"'{project}'는 유효하지 않은 프로젝트명입니다. "
+                        f"가능한 값: {', '.join(active_projects.keys())}"
+                    )
+                properties["프로젝트"] = {"relation": [{"id": active_projects[project]}]}
 
         if notion_assignee_id:
             properties["담당자"] = {"people": [{"id": notion_assignee_id}]}
@@ -431,7 +463,7 @@ def get_create_notion_task_tool(
                 properties["아이디어 뱅크"] = {"checkbox": True}
 
         response = notion.pages.create(
-            parent={"data_source_id": data_source_id}, properties=properties
+            parent={"data_source_id": actual_ds_id}, properties=properties
         )
 
         page_id = response["id"]

--- a/app/common.py
+++ b/app/common.py
@@ -450,7 +450,9 @@ def get_create_notion_task_tool(
                         f"'{project}'는 유효하지 않은 프로젝트명입니다. "
                         f"가능한 값: {', '.join(active_projects.keys())}"
                     )
-                properties["프로젝트"] = {"relation": [{"id": active_projects[project]}]}
+                properties["프로젝트"] = {
+                    "relation": [{"id": active_projects[project]}]
+                }
 
         if notion_assignee_id:
             properties["담당자"] = {"people": [{"id": notion_assignee_id}]}

--- a/app/general.py
+++ b/app/general.py
@@ -118,10 +118,22 @@ def register_general_handlers(app, assistant):
             task_ds_id = squad.notion_db.data_source_id
             title_prop = squad.notion_db.properties.title
             project_ds_id = None
+            default_db_name = squad.notion_db.name
         else:
             task_ds_id = DATA_SOURCE_ID
             title_prop = "제목"
             project_ds_id = PROJECT_DATA_SOURCE_ID
+            default_db_name = "main"
+
+        # 모든 설정된 DB 정보를 빌드하여 LLM이 대상 DB를 선택할 수 있게 함
+        config = load_config()
+        all_databases = {
+            name: {
+                "data_source_id": db.data_source_id,
+                "title_property": db.properties.title,
+            }
+            for name, db in config.notion_databases.items()
+        }
 
         # General Agent 사용
         notion_tools = [
@@ -132,6 +144,8 @@ def register_general_handlers(app, assistant):
                 app.client,
                 project_ds_id,
                 title_prop,
+                all_databases=all_databases,
+                default_db_name=default_db_name,
             ),
             get_update_notion_task_deadline_tool(),
             get_update_notion_task_status_tool(task_ds_id),
@@ -223,10 +237,22 @@ def register_general_handlers(app, assistant):
             task_ds_id = squad.notion_db.data_source_id
             title_prop = squad.notion_db.properties.title
             project_ds_id = None
+            default_db_name = squad.notion_db.name
         else:
             task_ds_id = DATA_SOURCE_ID
             title_prop = "제목"
             project_ds_id = PROJECT_DATA_SOURCE_ID
+            default_db_name = "main"
+
+        # 모든 설정된 DB 정보를 빌드하여 LLM이 대상 DB를 선택할 수 있게 함
+        config = load_config()
+        all_databases = {
+            name: {
+                "data_source_id": db.data_source_id,
+                "title_property": db.properties.title,
+            }
+            for name, db in config.notion_databases.items()
+        }
 
         notion_tools = [
             get_create_notion_task_tool(
@@ -236,6 +262,8 @@ def register_general_handlers(app, assistant):
                 app.client,
                 project_ds_id,
                 title_prop,
+                all_databases=all_databases,
+                default_db_name=default_db_name,
             ),
             get_update_notion_task_deadline_tool(),
             get_update_notion_task_status_tool(task_ds_id),


### PR DESCRIPTION
## Summary
- `create_notion_task` LLM 도구에 `target_database` 파라미터를 추가하여, 사용자가 "인프라 과업", "INF 티커" 등 특정 DB를 명시하면 LLM이 해당 DB에 과업을 생성할 수 있도록 함
- 기존에는 사용자의 Slack usergroup 기반 스쿼드로만 DB가 결정되어, 다른 DB에 과업 생성을 요청해도 기본 DB에만 생성되는 문제가 있었음
- `app_mention`과 `respond_in_assistant_thread` 두 핸들러 모두에 동일하게 적용

## Changes
### `app/common.py`
- `get_create_notion_task_tool`에 `all_databases`, `default_db_name` 파라미터 추가
- 도구 입력 스키마에 `target_database` 필드 추가 (설정된 모든 DB를 enum으로 제공)
- 도구 실행 시 `target_database`가 지정되면 해당 DB의 data_source_id와 title property를 사용
- 기본 DB가 아닌 DB로 오버라이드할 경우, 기본 DB 전용 속성(유형/구성요소/프로젝트)은 건너뜀

### `app/general.py`
- 두 핸들러에서 `load_config()`로 전체 DB 설정을 로드하여 `all_databases` dict 구성
- `get_create_notion_task_tool` 호출 시 `all_databases`와 `default_db_name` 전달

## Context
Slack: https://monolith-keb2010.slack.com/archives/C04F0S33HCL/p1780038287873009?thread_ts=1780037491.498299&cid=C04F0S33HCL
Notion: https://www.notion.so/WA-DB-36f1cc820da68166a4ecede068c69c8e

🤖 Generated with [Claude Code](https://claude.com/claude-code)