### PR TITLE
feat: 복수 스쿼드 소속 사용자의 우선 스쿼드 오버라이드 기능

### DIFF
--- a/app/general.py
+++ b/app/general.py
@@ -45,6 +45,11 @@ async def _get_user_squad(client: AsyncWebClient, user_id: str | None) -> Squad 
         return None
 
     config = load_config()
+
+    # 사용자별 오버라이드 확인 (복수 스쿼드 소속 시 우선 스쿼드 지정)
+    if user_id in config.squad_overrides:
+        return config.squad_overrides[user_id]
+
     for squad in config.squads:
         cache_key = f"usergroup_{squad.slack_usergroup_id}"
         if cache_key not in _cache_usergroup_members:

--- a/config.yaml
+++ b/config.yaml
@@ -90,6 +90,10 @@ squads:
     slack_usergroup_id: "S08LHAA2HL3"
     notion_db: contents
 
+# 복수 스쿼드에 소속된 사용자의 우선 스쿼드 지정
+squad_overrides:
+  "U07RP7U3FPU": "ie"  # 박기영: 인프라 팀 우선
+
 scrum:
   pr_warning_excluded_members:
     - "U075PUFNGHX"  # 예진 이 (코들 PM)

--- a/service/config.py
+++ b/service/config.py
@@ -144,6 +144,7 @@ class AppConfig:
 
     notion_databases: dict[str, NotionDBConfig]
     squads: list[Squad]
+    squad_overrides: dict[str, Squad]
     scrum: ScrumConfig
     task_alerts: TaskAlertsConfig
     deployment_rotation: DeploymentRotationConfig | None = None
@@ -191,6 +192,16 @@ def _parse_config(raw: dict) -> AppConfig:
         )
         squads.append(squad)
         squad_by_handle[squad.handle] = squad
+
+    # Squad overrides (사용자별 우선 스쿼드)
+    squad_overrides: dict[str, Squad] = {}
+    for user_id, handle in raw.get("squad_overrides", {}).items():
+        if handle not in squad_by_handle:
+            raise ValueError(
+                f"squad_overrides의 '{user_id}'가 참조하는 "
+                f"squad handle '{handle}'이 squads에 없습니다."
+            )
+        squad_overrides[user_id] = squad_by_handle[handle]
 
     # Scrum
     scrum_raw = raw.get("scrum", {})
@@ -272,6 +283,7 @@ def _parse_config(raw: dict) -> AppConfig:
     return AppConfig(
         notion_databases=notion_databases,
         squads=squads,
+        squad_overrides=squad_overrides,
         scrum=scrum,
         task_alerts=task_alerts,
         deployment_rotation=deployment_rotation,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,6 +114,40 @@ def test_task_alert_pipelines():
     assert "alert_schedule_feasibility" not in contents.pipeline_squads[0].alerts
 
 
+def test_squad_overrides():
+    """squad_overrides가 올바르게 파싱되는지 검증"""
+    config = load_config(CONFIG_PATH)
+
+    assert "U07RP7U3FPU" in config.squad_overrides
+    assert config.squad_overrides["U07RP7U3FPU"].handle == "ie"
+    assert config.squad_overrides["U07RP7U3FPU"].notion_db.name == "infra"
+
+
+def test_invalid_squad_override_reference():
+    """squad_overrides에서 존재하지 않는 squad handle 참조 시 ValueError"""
+    raw = {
+        "notion_databases": {
+            "db1": {
+                "data_source_id": "x",
+                "properties": {
+                    "title": "t",
+                    "status": "s",
+                    "assignee": "a",
+                    "timeline": "tl",
+                },
+            }
+        },
+        "squads": [{"handle": "a", "slack_usergroup_id": "S1", "notion_db": "db1"}],
+        "squad_overrides": {"U000": "nonexistent"},
+    }
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(raw, f)
+        f.flush()
+        with pytest.raises(ValueError, match="nonexistent"):
+            load_config(f.name)
+    os.unlink(f.name)
+
+
 def test_invalid_squad_db_reference():
     """존재하지 않는 notion_db 참조 시 ValueError"""
     raw = {


### PR DESCRIPTION
## Summary
- 여러 스쿼드에 동시 소속된 사용자가 과업 생성 시 의도하지 않은 스쿼드 DB에 과업이 생성되는 문제 해결
- `config.yaml`에 `squad_overrides` 설정 추가: 사용자별 우선 스쿼드를 지정 가능
- 박기영님(`U07RP7U3FPU`)이 해커톤/인프라 동시 소속 시 인프라 로드맵에 과업 생성되도록 설정

## Changes
- **config.yaml**: `squad_overrides` 섹션 추가 (user_id → squad handle 매핑)
- **service/config.py**: `AppConfig`에 `squad_overrides` 필드 추가 및 파싱 로직 구현 (잘못된 handle 참조 시 ValueError)
- **app/general.py**: `_get_user_squad()`에서 usergroup 순회 전 오버라이드 먼저 확인
- **tests/test_config.py**: 오버라이드 파싱 및 잘못된 참조 에러 테스트 추가

## Test plan
- [x] 기존 config 테스트 10개 모두 통과
- [x] 새 테스트 2개 추가 (정상 파싱, 잘못된 handle ValueError)
- [ ] 배포 후 박기영님이 로봇에게 과업 생성 요청 시 인프라 로드맵에 생성되는지 확인

Slack: https://monolith-keb2010.slack.com/archives/C0AHU2XDBT2/p1780280804528099

🤖 Generated with [Claude Code](https://claude.com/claude-code)