### PR TITLE
fix: manage_tasks_daily에서 squad_overrides 적용

### DIFF
--- a/scripts/manage_tasks_daily.py
+++ b/scripts/manage_tasks_daily.py
@@ -83,6 +83,15 @@ def main(dry_run: bool = False):
                 if result:
                     items.extend(result)
 
+            # squad_overrides: 다른 스쿼드로 오버라이드된 사용자 제외
+            items = [
+                (uid, text)
+                for uid, text in items
+                if uid is None
+                or uid not in config.squad_overrides
+                or config.squad_overrides[uid].handle == squad.handle
+            ]
+
             # 담당자별 그룹핑 후 메시지 전송
             if items:
                 _send_squad_summary(


### PR DESCRIPTION
## Summary
- `manage_tasks_daily.py`의 알림 수집 후 `config.squad_overrides`를 확인하여, 다른 스쿼드로 오버라이드된 사용자의 알림을 해당 스쿼드에서 제외
- 기존에 스크럼 시스템(`post_scrum_message.py`)에서만 적용되던 `squad_overrides`를 작업 알림 시스템에도 동일하게 적용

## Background
복수 Slack 유저그룹에 소속된 사용자(예: 코들 + 인프라)가 `squad_overrides`로 인프라로 지정되어 있음에도, 코들 스쿼드의 `alert_no_tasks`가 메인 DB에서 해당 사용자의 작업을 찾지 못해 "현재 진행중인 작업이 없습니다" 알림을 잘못 발송.

Slack 요청: https://monolith-keb2010.slack.com/archives/C087PDC9VG8/p1780632642548059?thread_ts=1780614917.325569&cid=C087PDC9VG8

## Test plan
- [ ] `--dry-run` 모드로 실행하여 오버라이드된 사용자가 비오버라이드 스쿼드에서 제외되는지 확인
- [ ] 오버라이드된 스쿼드에서는 정상적으로 알림이 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)