### PR TITLE
feat: Dependabot PR 자동 병합 (minor 이하 + CI 통과)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -284,6 +284,13 @@ scheduled_jobs:
       minute: "*/10"
     business_day_only: false
 
+  - name: merge_dependabot_prs
+    module: scripts.github_admin.merge_dependabot_prs
+    function: main
+    cron:
+      minute: 40            # 매시 40분, Dependabot PR의 CI 완료를 기다렸다가 병합
+    business_day_only: false
+
   - name: crawl_education_bids
     module: scripts.crawl_education_bids
     function: main

--- a/scripts/github_admin/merge_dependabot_prs.py
+++ b/scripts/github_admin/merge_dependabot_prs.py
@@ -1,0 +1,242 @@
+"""
+Organization의 Dependabot PR 중 minor 이하 업데이트이면서 CI를 통과한 PR을 자동 병합하는 스크립트
+
+GitHub Search API로 org 전체의 열린 Dependabot PR을 조회한 뒤,
+PR 제목에서 버전 변경 폭을 판별하고 head 커밋의 CI 결과를 확인하여 병합합니다.
+
+병합 조건:
+- PR 제목에서 before/after 버전을 파싱할 수 있어야 함 (그룹 업데이트 PR은 제외)
+- major 버전이 동일해야 함 (단, 0.x 버전은 minor까지 동일해야 함)
+- head 커밋에 check run 또는 commit status가 1개 이상 존재하고 모두 통과해야 함
+
+사용법:
+    python scripts/github_admin/merge_dependabot_prs.py [--dry-run]
+
+옵션:
+    --dry-run: 실제 병합 없이 어떤 PR이 병합될지 확인
+"""
+
+import argparse
+import os
+import re
+import sys
+
+from github import GithubException
+from github.Commit import Commit
+from github.PullRequest import PullRequest
+
+# 프로젝트 루트를 Python 경로에 추가
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from scripts.github_admin.common import get_github_client, get_org_name
+
+# check run conclusion 중 실패로 간주하는 값
+FAILURE_CONCLUSIONS = {"failure", "timed_out", "cancelled", "action_required", "stale"}
+
+
+def parse_version(text: str) -> tuple[int, ...] | None:
+    """
+    문자열에서 버전 숫자 튜플을 추출하는 함수
+
+    Args:
+        text: "1.2.3", "v4", "~> 7.0" 등 버전을 포함한 문자열
+
+    Returns:
+        tuple[int, ...] | None: (major, minor, patch) 형태의 튜플. 파싱 불가 시 None
+    """
+    match = re.search(r"v?(\d+(?:\.\d+)*)", text)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def parse_update_versions(title: str) -> tuple[tuple[int, ...], tuple[int, ...]] | None:
+    """
+    Dependabot PR 제목에서 변경 전/후 버전을 파싱하는 함수
+
+    "Bump foo from 1.2.3 to 1.4.0", "Update bar requirement from ~> 7.0 to ~> 7.1"
+    형태를 지원합니다. 그룹 업데이트 제목("Bump the npm group with 3 updates")은
+    버전 정보가 없으므로 None을 반환합니다.
+
+    Args:
+        title: PR 제목
+
+    Returns:
+        tuple | None: (before, after) 버전 튜플 쌍. 파싱 불가 시 None
+    """
+    match = re.search(r" from (?P<before>.+) to (?P<after>.+)$", title)
+    if not match:
+        return None
+
+    before = parse_version(match.group("before"))
+    after = parse_version(match.group("after"))
+    if before is None or after is None:
+        return None
+    return before, after
+
+
+def is_minor_or_lower_update(before: tuple[int, ...], after: tuple[int, ...]) -> bool:
+    """
+    버전 변경이 minor 이하인지 판별하는 함수
+
+    major 버전이 동일하면 minor 이하 업데이트로 간주합니다.
+    0.x 버전은 semver 관례상 minor 변경도 breaking이므로 minor까지 동일해야 합니다.
+
+    Args:
+        before: 변경 전 버전 튜플
+        after: 변경 후 버전 튜플
+
+    Returns:
+        bool: minor 이하 업데이트면 True
+    """
+    if before[0] != after[0]:
+        return False
+    if before[0] == 0:
+        return before[1:2] == after[1:2]
+    return True
+
+
+def get_ci_state(commit: Commit) -> str:
+    """
+    커밋의 CI 결과를 종합하여 상태를 반환하는 함수
+
+    GitHub Actions 등의 check run과 외부 CI의 commit status를 모두 확인합니다.
+
+    Args:
+        commit: PR head 커밋
+
+    Returns:
+        str: "success" | "pending" | "failure" | "none" (CI 없음)
+    """
+    states: set[str] = set()
+
+    for run in commit.get_check_runs():
+        if run.status != "completed":
+            states.add("pending")
+        elif run.conclusion in FAILURE_CONCLUSIONS:
+            states.add("failure")
+        else:
+            states.add("success")
+
+    combined = commit.get_combined_status()
+    if combined.total_count > 0:
+        states.add(combined.state)
+
+    if not states:
+        return "none"
+    if "failure" in states or "error" in states:
+        return "failure"
+    if "pending" in states:
+        return "pending"
+    return "success"
+
+
+def evaluate_pr(pr: PullRequest) -> tuple[bool, str]:
+    """
+    Dependabot PR이 자동 병합 대상인지 평가하는 함수
+
+    Args:
+        pr: 평가할 PR
+
+    Returns:
+        tuple[bool, str]: (병합 가능 여부, 사유)
+    """
+    if pr.draft:
+        return False, "draft PR"
+
+    versions = parse_update_versions(pr.title)
+    if versions is None:
+        return False, "버전 파싱 불가 (그룹 업데이트 등)"
+
+    before, after = versions
+    if not is_minor_or_lower_update(before, after):
+        return (
+            False,
+            f"major 업데이트 ({format_version(before)} -> {format_version(after)})",
+        )
+
+    ci_state = get_ci_state(pr.head.repo.get_commit(pr.head.sha))
+    if ci_state == "none":
+        return False, "CI 없음"
+    if ci_state != "success":
+        return False, f"CI {ci_state}"
+
+    return (
+        True,
+        f"minor 이하 ({format_version(before)} -> {format_version(after)}) + CI 통과",
+    )
+
+
+def format_version(version: tuple[int, ...]) -> str:
+    """버전 튜플을 점으로 구분된 문자열로 변환하는 함수"""
+    return ".".join(str(part) for part in version)
+
+
+def merge_pr(pr: PullRequest) -> None:
+    """
+    PR을 병합하는 함수
+
+    리포지토리가 squash 병합을 허용하면 squash, 아니면 merge 방식을 사용합니다.
+
+    Args:
+        pr: 병합할 PR
+    """
+    merge_method = "squash" if pr.base.repo.allow_squash_merge else "merge"
+    pr.merge(merge_method=merge_method)
+
+
+def main(dry_run: bool = False):
+    """
+    Org 전체의 Dependabot PR을 조회하여 조건을 만족하는 PR을 병합하는 메인 함수
+
+    Args:
+        dry_run: True면 실제 병합 없이 대상 PR만 출력
+    """
+    g = get_github_client()
+    org_name = get_org_name()
+
+    issues = g.search_issues(
+        f"org:{org_name} is:pr is:open author:app/dependabot archived:false"
+    )
+
+    merged_count = 0
+    skip_count = 0
+    error_count = 0
+
+    for issue in issues:
+        pr = issue.as_pull_request()
+        label = f"{pr.base.repo.full_name}#{pr.number}"
+
+        try:
+            should_merge, reason = evaluate_pr(pr)
+            if not should_merge:
+                print(f"[SKIP] {label}: {reason} - {pr.title}")
+                skip_count += 1
+                continue
+
+            if dry_run:
+                print(f"[DRY-RUN] {label}: 병합 예정 ({reason}) - {pr.title}")
+            else:
+                merge_pr(pr)
+                print(f"[MERGED] {label}: {reason} - {pr.title}")
+            merged_count += 1
+
+        except GithubException as e:
+            print(f"[ERROR] {label}: {e.data.get('message', str(e))}")
+            error_count += 1
+
+    print("-" * 50)
+    print(f"완료: 병합 {merged_count}, 스킵 {skip_count}, 오류 {error_count}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Dependabot PR 중 minor 이하 + CI 통과 PR을 자동 병합합니다."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="실제 병합 없이 어떤 PR이 병합될지 확인",
+    )
+    args = parser.parse_args()
+    main(dry_run=args.dry_run)

--- a/tests/test_merge_dependabot_prs.py
+++ b/tests/test_merge_dependabot_prs.py
@@ -1,0 +1,107 @@
+"""merge_dependabot_prs 스크립트의 버전 파싱 및 병합 판단 로직 테스트"""
+
+from unittest.mock import MagicMock
+
+from scripts.github_admin.merge_dependabot_prs import (
+    get_ci_state,
+    is_minor_or_lower_update,
+    parse_update_versions,
+    parse_version,
+)
+
+
+class TestParseVersion:
+    def test_semver(self):
+        assert parse_version("1.2.3") == (1, 2, 3)
+
+    def test_v_prefix(self):
+        assert parse_version("v4") == (4,)
+
+    def test_ruby_requirement(self):
+        assert parse_version("~> 7.0") == (7, 0)
+
+    def test_no_version(self):
+        assert parse_version("latest") is None
+
+
+class TestParseUpdateVersions:
+    def test_bump_title(self):
+        title = "Bump lodash from 4.17.20 to 4.17.21"
+        assert parse_update_versions(title) == ((4, 17, 20), (4, 17, 21))
+
+    def test_requirement_title(self):
+        title = "Update rails requirement from ~> 7.0 to ~> 7.1"
+        assert parse_update_versions(title) == ((7, 0), (7, 1))
+
+    def test_github_actions_title(self):
+        title = "Bump actions/checkout from 3 to 4"
+        assert parse_update_versions(title) == ((3,), (4,))
+
+    def test_group_update_title(self):
+        title = "Bump the npm_and_yarn group with 3 updates"
+        assert parse_update_versions(title) is None
+
+    def test_directory_prefix_title(self):
+        title = "Bump axios from 1.6.0 to 1.7.2 in /frontend"
+        assert parse_update_versions(title) == ((1, 6, 0), (1, 7, 2))
+
+
+class TestIsMinorOrLowerUpdate:
+    def test_minor_update(self):
+        assert is_minor_or_lower_update((1, 2, 0), (1, 3, 0)) is True
+
+    def test_patch_update(self):
+        assert is_minor_or_lower_update((1, 2, 0), (1, 2, 1)) is True
+
+    def test_major_update(self):
+        assert is_minor_or_lower_update((1, 9, 0), (2, 0, 0)) is False
+
+    def test_zero_major_minor_update_is_breaking(self):
+        assert is_minor_or_lower_update((0, 1, 0), (0, 2, 0)) is False
+
+    def test_zero_major_patch_update(self):
+        assert is_minor_or_lower_update((0, 1, 0), (0, 1, 5)) is True
+
+
+def make_commit(check_runs: list[tuple[str, str | None]], combined_state: str | None):
+    """check run (status, conclusion) 목록과 combined status로 mock 커밋 생성"""
+    commit = MagicMock()
+    runs = []
+    for status, conclusion in check_runs:
+        run = MagicMock()
+        run.status = status
+        run.conclusion = conclusion
+        runs.append(run)
+    commit.get_check_runs.return_value = runs
+
+    combined = MagicMock()
+    combined.total_count = 1 if combined_state else 0
+    combined.state = combined_state
+    commit.get_combined_status.return_value = combined
+    return commit
+
+
+class TestGetCiState:
+    def test_all_success(self):
+        commit = make_commit([("completed", "success"), ("completed", "skipped")], None)
+        assert get_ci_state(commit) == "success"
+
+    def test_failure(self):
+        commit = make_commit([("completed", "success"), ("completed", "failure")], None)
+        assert get_ci_state(commit) == "failure"
+
+    def test_pending(self):
+        commit = make_commit([("in_progress", None)], None)
+        assert get_ci_state(commit) == "pending"
+
+    def test_no_ci(self):
+        commit = make_commit([], None)
+        assert get_ci_state(commit) == "none"
+
+    def test_combined_status_failure(self):
+        commit = make_commit([("completed", "success")], "failure")
+        assert get_ci_state(commit) == "failure"
+
+    def test_combined_status_only_success(self):
+        commit = make_commit([], "success")
+        assert get_ci_state(commit) == "success"


### PR DESCRIPTION
## 배경

Dependabot을 GitHub Org 수준에서 전역 설정함에 따라, minor 이하 버전 업데이트이면서 CI를 통과한 PR을 자동 병합하는 스케줄 작업을 추가합니다.

## 변경사항

- `scripts/github_admin/merge_dependabot_prs.py`: Search API로 org 전체의 열린 Dependabot PR을 조회하여 병합 조건을 평가하고 병합 (`--dry-run` 지원)
- `config.yaml`: 매시 40분 실행 스케줄 등록
- 병합 조건
  - PR 제목에서 before/after 버전 파싱 가능 (그룹 업데이트 PR은 보수적으로 스킵)
  - major 버전 동일 (0.x 버전은 semver 관례상 minor까지 동일해야 함)
  - head 커밋에 check run 또는 commit status가 1개 이상 존재하고 모두 통과 (CI 없는 레포는 스킵)

## 대안 분석

- GitHub 네이티브 auto-merge: 현행 ruleset에 required_status_checks가 없어 CI를 기다리지 않고 병합되며, 리뷰 1명 요건 때문에 사람 승인 전까지 병합되지 않음. 레포별 CI 체크 이름 표준화가 선행돼야 성립하므로 제외.
- 레포별 Actions 워크플로우(`dependabot/fetch-metadata`): 수십 개 레포에 워크플로우 배포·유지 필요. org 전역 중앙 관리 취지와 상반되어 제외.

표준 ruleset의 리뷰 1명 요건은 admin 토큰의 bypass로 우회하여 병합합니다. minor + CI 통과 시 사람 리뷰를 생략하는 것이 이 작업의 취지입니다.

## 검증

- 실제 org 대상 dry-run: Dependabot PR 44건 중 7건 병합 대상, major 업데이트·CI 실패·CI 없음·그룹 업데이트는 모두 스킵 확인
- `pytest` 134 passed (버전 파싱·minor 판별·CI 상태 종합 단위 테스트 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)