### PR TITLE
fix: Dependabot 자동병합 잡이 GITHUB_TOKEN을 사용하도록 변경

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -285,7 +285,7 @@ scheduled_jobs:
     business_day_only: false
 
   - name: merge_dependabot_prs
-    module: scripts.github_admin.merge_dependabot_prs
+    module: scripts.merge_dependabot_prs
     function: main
     cron:
       minute: 40            # 매시 40분, Dependabot PR의 CI 완료를 기다렸다가 병합

--- a/scripts/github_admin/merge_dependabot_prs.py
+++ b/scripts/github_admin/merge_dependabot_prs.py
@@ -28,17 +28,17 @@ GitHub Search API로 org 전체의 열린 Dependabot PR을 조회한 뒤 (레포
 import argparse
 import os
 import re
-import sys
 from typing import Literal
 
 import yaml
-from github import GithubException
+from dotenv import load_dotenv
+from github import Github, GithubException
 from github.PullRequest import PullRequest
 
-# 프로젝트 루트를 Python 경로에 추가
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+load_dotenv()
 
-from scripts.github_admin.common import get_github_client, get_org_name
+# GitHub 조직 이름 (다른 스케줄 잡과 동일하게 상수로 둠)
+ORG_NAME = "team-monolith-product"
 
 # check run conclusion 중 실패로 간주하는 값
 FAILURE_CONCLUSIONS = {"failure", "timed_out", "cancelled", "action_required", "stale"}
@@ -243,12 +243,11 @@ def main(dry_run: bool = False):
     Args:
         dry_run: True면 실제 approve/병합 없이 대상 PR만 출력
     """
-    g = get_github_client()
-    org_name = get_org_name()
+    g = Github(os.environ["GITHUB_TOKEN"])
     reviewer_login = g.get_user().login
 
     issues = g.search_issues(
-        f"org:{org_name} is:pr is:open author:app/dependabot archived:false"
+        f"org:{ORG_NAME} is:pr is:open author:app/dependabot archived:false"
     )
 
     merged_count = 0

--- a/scripts/merge_dependabot_prs.py
+++ b/scripts/merge_dependabot_prs.py
@@ -19,7 +19,7 @@ GitHub Search API로 org 전체의 열린 Dependabot PR을 조회한 뒤 (레포
 충족되므로 bypass에 의존하지 않습니다.
 
 사용법:
-    python scripts/github_admin/merge_dependabot_prs.py [--dry-run]
+    python scripts/merge_dependabot_prs.py [--dry-run]
 
 옵션:
     --dry-run: 실제 approve/병합 없이 어떤 PR이 병합될지 확인

--- a/tests/test_merge_dependabot_prs.py
+++ b/tests/test_merge_dependabot_prs.py
@@ -1,6 +1,6 @@
 """merge_dependabot_prs 스크립트의 커밋 메타데이터 파싱 및 병합 정책 테스트"""
 
-from scripts.github_admin.merge_dependabot_prs import (
+from scripts.merge_dependabot_prs import (
     evaluate_ci,
     evaluate_updates,
     is_minor_or_lower_update,


### PR DESCRIPTION
## 배경

#125 머지 후 배포된 잡이 매시 :40 발화마다 실패하고 있습니다. slackbot 파드 로그:

```
[scheduler] merge_dependabot_prs: 실행 시작
Job "merge_dependabot_prs ..." raised an exception
ValueError: GITHUB_ADMIN_TOKEN 환경변수가 설정되지 않았습니다.
```

원인: 스케줄러가 도는 파드에는 `GITHUB_TOKEN`(머신 계정 github-machine-monolith, repo 스코프)만 주입돼 있고 `GITHUB_ADMIN_TOKEN`·`GITHUB_ORG_NAME`은 없습니다. 그런데 이 잡만 `common.get_github_client()`(로컬 admin 스크립트용, GITHUB_ADMIN_TOKEN을 읽음)를 사용해 루프 진입 전 즉사했습니다. 대상 5건은 approve조차 안 된 채 미병합 상태였습니다.

## 변경사항

다른 스케줄 잡(`collect_review_stats`, `collect_coding_rule_feedbacks`)과 동일한 컨벤션으로 맞춥니다:

- `Github(os.environ["GITHUB_TOKEN"])` 직접 사용
- `ORG_NAME = "team-monolith-product"` 상수
- 파일을 `scripts/merge_dependabot_prs.py`로 이동 — `scripts/github_admin/`은 GITHUB_ADMIN_TOKEN 기반 로컬 admin 스크립트 패키지이므로, 스케줄 잡은 다른 잡들과 같이 `scripts/` 바로 아래에 둠 (config.yaml 모듈 경로 갱신)

`repo` 스코프면 approve/merge에 충분하므로 인프라 시크릿 추가가 불필요합니다. 항상 떠있는 파드에 admin:org 토큰을 두지 않는 편이 보안상으로도 낫습니다.

## 검증

- pytest 26 passed, dry-run(병합 5, 오류 0) — GITHUB_TOKEN 경로로 정상 동작 확인

## 후속 (이 PR 범위 밖)

스케줄러 예외가 stdout에는 찍히나 Sentry에는 안 올라오는 모니터링 공백이 이번에 드러났습니다(app.py가 Sentry init을 하는데도). scheduler.py 래퍼에서 `capture_exception` 후 re-raise하면 앞으로 크론 실패가 묻히지 않습니다 — 별도로 처리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
