### PR TITLE
feat(github_admin): Main Protection 룰셋에 Renovate App bypass 추가

### DIFF
--- a/scripts/github_admin/ruleset.json
+++ b/scripts/github_admin/ruleset.json
@@ -38,6 +38,11 @@
       "actor_id": 1,
       "actor_type": "OrganizationAdmin",
       "bypass_mode": "always"
+    },
+    {
+      "actor_id": 4068636,
+      "actor_type": "Integration",
+      "bypass_mode": "pull_request"
     }
   ]
 }


### PR DESCRIPTION
## 배경

강 CI 백엔드 minor 이하 automerge(Renovate)가 5개 중 3개에서 실제로는 동작하지 않는다. `jce-class-rails`·`jce-user-rails`·`jce-ai-fastapi` 는 기본 룰셋 `Main Protection By Security`(필수 승인 1)를 받는데, Renovate 는 자기 PR 의 작성자라 승인을 스스로 채울 수 없어 self-merge 가 막힌다. 현재 bypass 에는 Team·OrgAdmin 만 있고 Renovate App 이 없다. (enk-user-rails·enk-hackathon-rails 는 이 룰셋을 skip 해 영향 없음.)

## 변경

`scripts/github_admin/ruleset.json` 의 bypass_actors 에 Renovate App 추가:

```json
{ "actor_id": 4068636, "actor_type": "Integration", "bypass_mode": "pull_request" }
```

## 결정

- 공유 `ruleset.json`(Main Protection)에 추가했다. 레포별 변종 룰셋을 새로 만들면 룰셋 정의 전체와 대상 레포 목록을 또 한 벌 복제해야 해 유지보수가 나빠진다. 공유 룰셋에 두면 이후 온보딩되는 백엔드도 자동 적용된다.
- `bypass_mode: pull_request` — Renovate 는 PR 로만 머지하므로 PR 경유 bypass 만 부여하고 직접 push bypass 는 주지 않는다(최소권한).
- 스코프: 이 bypass 는 `Main Protection By Security` 를 받는 모든 레포에 부여되지만, 실효 범위는 Renovate 가 실제로 설정된 레포(현재 강 CI 백엔드 5종)로 한정된다. 더 좁히길 원하면 전용 룰셋 변종으로 분리 가능 — 보안팀 판단.

## 적용

`add_ruleset.py` 는 cron 없는 수동 스크립트라 머지만으로 반영되지 않는다. 머지 후 admin 이 `GITHUB_ADMIN_TOKEN` 으로 `python scripts/github_admin/add_ruleset.py` 실행 시 org 전체에 재적용된다. 적용 후 백엔드 1곳에서 Renovate automerge 가 실제로 머지되는지 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)