### PR TITLE
feat(github_admin): enk-* 룰셋을 enk-* glob으로 통합 (Main Force Push만 적용)

### DIFF
--- a/scripts/github_admin/repo_rulesets_config.json
+++ b/scripts/github_admin/repo_rulesets_config.json
@@ -26,28 +26,9 @@
     "skip": ["ruleset.json", "ruleset_develop.json"],
     "add": ["ruleset_main_force_push_only.json"]
   },
-  "enk-opencode-hub-helm": {
+  "enk-*": {
     "skip": ["ruleset.json", "ruleset_develop.json"],
     "add": ["ruleset_main_force_push_only.json"]
-  },
-  "enk-hackathon-vite": {
-    "skip": ["ruleset.json", "ruleset_develop.json"],
-    "add": ["ruleset_main_force_push_only.json"]
-  },
-  "enk-landing-vite": {
-    "skip": ["ruleset.json", "ruleset_develop.json"],
-    "add": ["ruleset_main_force_push_only.json"]
-  },
-  "enk-hackathon-rails": {
-    "skip": ["ruleset.json", "ruleset_develop.json"],
-    "add": ["ruleset_main_force_push_only.json"]
-  },
-  "enk-user-rails": {
-    "skip": ["ruleset.json", "ruleset_develop.json"],
-    "add": ["ruleset_main_force_push_only.json"]
-  },
-  "enk-plan-md": {
-    "skip": ["ruleset.json"]
   },
   "tmn-n8n": {
     "skip": ["ruleset.json", "ruleset_develop.json"],


### PR DESCRIPTION
## 배경

직전 #129로 Main Protection(`ruleset.json`)에 Renovate App bypass가 추가됐지만, enk-* 레포는 레포별로 제각각 설정돼 있었다.

- 5개(opencode-hub-helm, hackathon-vite, landing-vite, hackathon-rails, user-rails): `force_push_only`
- `enk-admin-react`: 설정 누락 → org 기본인 Main Protection(PR 1 승인 강제) + Develop Protection
- `enk-plan-md`: `ruleset.json`만 skip → Develop Protection만 적용

enk-* 레포 정책을 하나로 통일한다.

## 변경사항

개별 enk 엔트리 6개를 단일 `enk-*` glob으로 통합. 모든 enk-* 레포가 `ruleset.json`/`ruleset_develop.json`을 skip하고 `ruleset_main_force_push_only.json`만 적용받는다.

`--dry-run` 검증 결과(비-fork enk 7개에만 매칭):

- `enk-admin-react`: Main Protection + Develop Protection 삭제 → Main Force Push Protection 추가 (PR 승인 강제 해제)
- `enk-plan-md`: Develop Protection 삭제 → Main Force Push Protection 추가
- 나머지 5개: 변화 없음(멱등 덮어쓰기)
- fork(`enk-opencode`, `enk-configurable-http-proxy`)는 `get_all_repos`의 fork 필터로 제외 → glob 비매칭

## 검증

`python scripts/github_admin/add_ruleset.py --dry-run` 으로 위 효과 및 glob 더블매칭 에러 없음 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)