### PR TITLE
feat(github_admin): tmn-landing-react에 force push 금지 룰셋만 적용

### DIFF
--- a/scripts/github_admin/repo_rulesets_config.json
+++ b/scripts/github_admin/repo_rulesets_config.json
@@ -6,6 +6,10 @@
     "skip": ["ruleset.json", "ruleset_develop.json"],
     "add": ["ruleset_main_landing_react.json"]
   },
+  "tmn-landing-react": {
+    "skip": ["ruleset.json", "ruleset_develop.json"],
+    "add": ["ruleset_main_force_push_only.json"]
+  },
   "tmn-e2e-video": {
     "skip": ["ruleset.json"]
   },


### PR DESCRIPTION
## 배경

tmn-landing-react에는 org 공통 `Main Protection`(PR 승인 1건 필수)이 걸려 있어, 배포 편의상 단순 force push 금지만 두기로 한다.

## 변경 사항

1. `repo_rulesets_config.json`에 `tmn-landing-react` 항목 추가
   - `skip`: `ruleset.json`(Main Protection, PR 필수), `ruleset_develop.json`(Develop Protection)
   - `add`: `ruleset_main_force_push_only.json`(deletion + non_fast_forward = force push 금지)
   - docgen·enk-*·tmn-n8n 등에 이미 쓰이는 force-push-only 패턴과 동일
2. `add_ruleset.py`에 `--repo REPO_NAME` 인자 추가
   - org 전체를 순회하지 않고 지정한 단일 repo에만 적용
   - config 검증/glob 확장은 기존처럼 org 전체 목록 기준으로 수행하여 동작 동일

## 검증

- `--repo tmn-landing-react --dry-run`으로 삭제 2건 + 추가 1건 계획 확인
- 실제 적용 후 라이브 룰셋 확인 (코멘트 참조)