### PR TITLE
fix: 멀티스테이지 빌드로 런타임 이미지 CVE 면적 축소 (git 제거)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,26 @@
-# 베이스 이미지 설정
-FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1 as prd
+# 빌드 도구(git 등)는 builder 단계에만 두고, 런타임 이미지(prd)에는 실행에 필요한 것만
+# 남겨 OS 패키지 CVE 노출 면적을 줄인다. git 이 끌어오는 libssh2·perl·libcurl·libtasn1 은
+# 런타임에서 쓰지 않으므로 최종 이미지에서 제외된다.
+
+# ===== Builder Stage =====
+FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1 AS builder
+
+WORKDIR /app
+
+# git: requirements.txt 의 `notion-to-md-py @ git+https://...` 설치에 필요 (빌드 타임 전용)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# 의존성을 격리된 venv 에 설치하여 런타임 단계로 통째로 복사한다.
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# ===== Production Stage =====
+FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1 AS prd
 
 # 환경 변수 설정 (Python 출력 버퍼링 비활성화)
 ENV PYTHONUNBUFFERED=1
@@ -10,15 +31,14 @@ WORKDIR /app
 # 한글 폰트 설치 (matplotlib 차트 한글 표시용)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-nanum \
-    git \
     && rm -rf /var/lib/apt/lists/*
 
 # matplotlib 폰트 캐시 삭제 (새 폰트 인식을 위해)
 RUN rm -rf /root/.cache/matplotlib
 
-# 필요한 패키지 설치
-COPY requirements.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+# builder 에서 설치한 의존성(venv) 복사
+ENV PATH="/opt/venv/bin:$PATH"
+COPY --from=builder /opt/venv /opt/venv
 
 # 애플리케이션 코드 복사
 COPY . .


### PR DESCRIPTION
## 배경

ECR `jce-ecr-workflow-automation-slack-all-prd` 스캔에서 CRITICAL 2 / HIGH 11 / MEDIUM 21 이 보고되었다. 대상 패키지(libssh2·libcurl/curl·libtasn1·perl)는 앱이 런타임에 쓰지 않으며, 모두 빌드 타임에만 필요한 `git` 이 끌어온 전이 의존성이다. `git` 은 `requirements.txt` 의 `notion-to-md-py @ git+https://...` 설치를 위해서만 들어가 있다 (코드에 런타임 git 호출 없음).

## 변경

단일 stage → 멀티스테이지로 전환한다. `builder` 에서 git 으로 의존성을 venv 에 설치하고, 깨끗한 `prd` stage 로 venv 만 복사한다. base digest 핀은 두 stage 모두 동일하게 유지한다 (Renovate 관리).

## 효과 (로컬 `docker build --target prd` + 컨테이너 검사로 확인)

런타임 이미지에서 제거됨:
- `libssh2` — CVE-2026-55200 (CRITICAL, RCE) 포함 6건
- `libcurl`/`curl` — 7건
- `libtasn1-6` — 1건
- `perl`/`perl-modules` — IO::Compress·IO::Uncompress·File::GlobMapper·HTTP::Tiny 등

잔존 (제거 불가, base 패치 영역):
- `perl-base` (essential) — `Socket` 모듈 보유 → CVE-2026-12087 (CRITICAL) 은 남는다
- `libexpat1` — python(pyexpat) 의존 → expat CVE 잔존

→ 잔존분은 `git` 제거로 해결되지 않으며, Renovate 의 base digest bump(Debian 패치 반영) 로 대응한다.

검증: 전 의존성 정상 import (matplotlib·pandas·lxml·PyMuPDF 네이티브 휠 + git 설치 패키지 `notion_to_md`), matplotlib NanumGothic 인식 OK.

## 대안 분석

- base digest bump 단독: trixie stable 은 libssh2 1.12.0·expat 2.8.2 를 제공하지 않아 불충분. 본 변경과 상호 보완.
- Alpine 이전: 패키지 면적은 더 작아지나 musl 휠 호환(matplotlib·pandas) 검증 부담이 커 별도 과제로 분리.