### PR TITLE
chore: tmn-react-mono를 main 보호 ruleset에서 제외

### DIFF
--- a/scripts/github_admin/repo_rulesets_config.json
+++ b/scripts/github_admin/repo_rulesets_config.json
@@ -19,6 +19,9 @@
   "tmn-component-screenshot": {
     "skip": ["ruleset.json"]
   },
+  "tmn-react-mono": {
+    "skip": ["ruleset.json"]
+  },
   "*-memory": {
     "skip": ["ruleset.json", "ruleset_develop.json"],
     "add": ["ruleset_main_force_push_only.json"]


### PR DESCRIPTION
## 개요
`tmn-react-mono` 레포를 org 전체 `Main Protection By Security` ruleset(main 브랜치 PR 필수 리뷰 규칙) 적용 대상에서 제외한다.

## 변경
`scripts/github_admin/repo_rulesets_config.json`에 아래 항목 추가 (`tmn-e2e-video` 등 기존 제외 항목과 동일 패턴):

```json
"tmn-react-mono": {
  "skip": ["ruleset.json"]
}
```

`develop` ruleset은 대상이 아니므로 건드리지 않았다.

## 적용
`add_ruleset.py`는 skip 대상에 기존 ruleset이 있으면 삭제하므로, 다음 실행 시 `tmn-react-mono`의 Main Protection ruleset이 제거된다.