### PR TITLE
fix(edu-bid): 담당 사업유형은 역량 키워드 없이도 후보로 채택

### DIFF
--- a/scripts/crawl_education_bids.py
+++ b/scripts/crawl_education_bids.py
@@ -60,16 +60,19 @@ def main():
     now = datetime.now(KST)
     window = stages.build_incremental_window(now)
 
+    # 어느 트랙이든 담당하는 사업유형 — 후보 채택(키워드∪담당유형)과 미매핑 집계에 함께 쓴다.
+    routed_types = {wt for t in cfg.tracks for wt in t.work_types}
+
     # 공유 상단부는 트랙 무관 — 공유 지식으로 한 번만 수집·게이트한다.
     gated = pipeline.prepare(
         window,
         load_shared_knowledge(),
+        routed_types,
         limit=args.limit,
         use_cache=not args.no_cache,
     )
 
     # 어느 트랙에도 매핑되지 않은 사업유형(연구·기타 등)은 평가 없이 누락된다 — 침묵 스킵 방지로 집계.
-    routed_types = {wt for t in cfg.tracks for wt in t.work_types}
     unrouted = Counter(
         a.work_type for a, _, _ in gated if a.work_type not in routed_types
     )

--- a/service/edu_bid/pipeline.py
+++ b/service/edu_bid/pipeline.py
@@ -1,8 +1,9 @@
 """
 오케스트레이터 — 단계를 순서대로 호출하는 얇은 조립부.
 
-공유 상단부(prepare): S0 수집 → S1 정규화/dedupe → S3 트리아지 → S3.5 사업유형 분류
-→ S2 게이트. 트랙 무관(공유 지식만 사용)으로 한 번만 돈다.
+공유 상단부(prepare): S0 수집 → S1 정규화/dedupe → S3.5 사업유형 분류 → S3 트리아지
+→ S2 게이트. 트랙 무관(공유 지식만 사용)으로 한 번만 돈다. 후보 채택은 역량 키워드
+매칭과 담당 사업유형 분류의 합집합이다(둘 중 하나만 걸려도 채택).
 트랙 하단부(run_track): 사업유형으로 후보를 갈라 트랙 지식으로 S5 평가 → S6 결정 →
 S4 정독 재평가. 트랙마다 다른 전략·점수정책·채널이 여기서 갈린다. 사업유형이 트랙을
 겹치지 않게 나누므로, 각 공고는 정확히 한 트랙에서 한 번만 평가된다(비용 1배).
@@ -20,14 +21,19 @@ GatedCandidate = tuple[Announcement, list[str], GateResult]
 def prepare(
     window: tuple[str, str],
     shared,
+    in_scope_work_types: set[str],
     *,
     limit: int | None = None,
     session=None,
     use_cache: bool = True,
 ) -> list[GatedCandidate]:
-    """공유 상단부. 수집·트리아지·사업유형·게이트까지 트랙 무관하게 한 번 돈다.
+    """공유 상단부. 수집·분류·트리아지·게이트까지 트랙 무관하게 한 번 돈다.
 
     shared 는 SharedKnowledge(역량·자격·소스·사업유형) — 트랙 전략·점수정책은 여기서 안 쓴다.
+    in_scope_work_types 는 어느 트랙이든 담당하는 사업유형 집합(config 의 tracks 에서 옴).
+    후보 채택은 합집합이다: 역량 키워드가 걸리거나(제품 호명), 담당 사업유형으로 분류되면
+    남긴다. 연수·역량강화처럼 우리 기술을 직접 호명하지 않는 교육운영 공고가 키워드 트리아지
+    단독 게이트에서 탈락하던 문제를 막는다(실제 적합도는 뒷단 LLM 평가의 reuse 축이 거른다).
     반환: 게이트 통과(pass/near_miss) 후보 [(ann, matched_assets, gate)].
     ann.work_type 이 채워진 상태로 넘어가 run_track 에서 트랙으로 분기된다.
     """
@@ -40,28 +46,29 @@ def prepare(
     anns = stages.dedupe_by_notice(anns)
     print(f"[edu-bid] 수집·dedupe: {len(anns)}건")
 
-    # S3 트리아지 (역량 키워드) — 비용 깔때기
+    # S3.5 사업유형 분류(무비용) → S3 트리아지(역량 키워드)와 합집합으로 후보 채택.
+    # 무관 유형은 분류 즉시 제외(LLM 비용 절감).
     kw_index = stages.build_keyword_index(shared.capability_profile)
-    candidates = [(a, m) for a in anns if (m := stages.triage(a, kw_index))]
-    print(f"[edu-bid] 트리아지 통과: {len(candidates)}건")
-
-    # S3.5 사업유형 분류 + 무관 유형 사전 제외(비용 절감)
     drop_types = set(shared.work_types.get("drop_for_eval", []))
-    kept: list[tuple] = []
+    candidates: list[tuple] = []
     dropped_wt = 0
-    for a, matched in candidates:
+    for a in anns:
         a.work_type = stages.classify_work_type(a, shared.work_types)
         if a.work_type in drop_types:
             dropped_wt += 1
-        else:
-            kept.append((a, matched))
-    print(f"[edu-bid] 사업유형 무관 제외: {dropped_wt}건 / 남은 후보: {len(kept)}건")
+            continue
+        matched = stages.triage(a, kw_index)
+        if matched or a.work_type in in_scope_work_types:
+            candidates.append((a, matched))
+    print(
+        f"[edu-bid] 사업유형 무관 제외: {dropped_wt}건 / 후보(키워드∪담당유형): {len(candidates)}건"
+    )
 
     # S2 게이트 — 참가 불가(fail)는 평가 전에 제외해 LLM 비용 절감.
     # near_miss/pass 만 평가 대상으로 넘긴다(near_miss 는 결정 단계에서 미래타깃 처리).
     gated: list[GatedCandidate] = []
     dropped_gate = 0
-    for ann, matched in kept:
+    for ann, matched in candidates:
         g = stages.gate(ann, shared.eligibility_ledger)
         if g.status == "fail":
             dropped_gate += 1

--- a/tests/test_crawl_education_bids.py
+++ b/tests/test_crawl_education_bids.py
@@ -440,6 +440,68 @@ def test_track_performance_is_per_track_and_empty():
         assert load_knowledge(key).track_performance == []
 
 
+# --- prepare (후보 채택: 키워드 ∪ 담당 사업유형) ---
+
+
+def test_prepare_admits_work_type_without_keyword(monkeypatch):
+    """우리 기술을 호명하지 않는 연수 공고는 트리아지 단독으론 탈락하지만,
+    교육운영으로 분류되면 담당 사업유형 합집합으로 채택된다(실제 누락 재현·수정)."""
+    from service.edu_bid import pipeline, sources
+
+    shared = load_shared_knowledge()
+    # 실제 슬랙에서 누락 제보된 제목 — 자산 키워드 미매칭, 제목 '연수' → 교육운영
+    yeonsu = _ann(
+        bid_no="R1",
+        title="2026년 AI·디지털 활용 수업혁신 역량강화(실습형) 연수 운영 위탁 용역",
+        demand_inst="○○교육청교육연수원",
+    )
+    # 무관 공고 — 트리아지도 분류도 탈락 → 제외
+    junk = _ann(
+        bid_no="R2",
+        title="가로수 전지 용역",
+        proc_large="폐기물 처리 및 재활용서비스",
+    )
+    monkeypatch.setattr(
+        sources,
+        "collect",
+        lambda kn, win, session=None, use_cache=True: [yeonsu, junk],
+    )
+
+    routed = {"개발", "유지관리", "콘텐츠", "교육운영", "행사"}
+    gated = pipeline.prepare(
+        ("202607190000", "202607200000"), shared, routed, use_cache=False
+    )
+
+    by_title = {a.title: (a, m, g) for a, m, g in gated}
+    assert yeonsu.title in by_title  # 담당 사업유형으로 채택
+    assert junk.title not in by_title  # 무관은 제외
+    a, matched, _ = by_title[yeonsu.title]
+    assert matched == []  # 자산 키워드는 안 걸렸어도 후보로 남는다
+    assert a.work_type == "교육운영"
+
+
+def test_prepare_excludes_off_scope_work_type_without_keyword(monkeypatch):
+    """담당 밖 사업유형(연구)은 키워드도 안 걸리면 채택하지 않는다(스코프 과확대 방지)."""
+    from service.edu_bid import pipeline, sources
+
+    shared = load_shared_knowledge()
+    research = _ann(
+        bid_no="R3",
+        title="청소년 진로 실태조사 연구용역",
+        proc_class="학술연구서비스",
+    )
+    monkeypatch.setattr(
+        sources,
+        "collect",
+        lambda kn, win, session=None, use_cache=True: [research],
+    )
+    routed = {"개발", "유지관리", "콘텐츠", "교육운영", "행사"}
+    gated = pipeline.prepare(
+        ("202607190000", "202607200000"), shared, routed, use_cache=False
+    )
+    assert gated == []  # 연구 = 담당 밖 + 키워드 미매칭 → 제외
+
+
 # --- run_track (사업유형 분기, LLM 모킹) ---
 
 


### PR DESCRIPTION
## 배경
교육/운영 공공입찰 채널(C0B7H27DFT7)에서 "2026년 AI·디지털 활용 수업혁신 역량강화(실습형) 연수 운영 위탁 용역"이 왜 안 뜨느냐는 제보. 서울시 연수사업은 뜨는데 이 건은 누락됐다.

## 원인
트리아지(`stages.triage`)가 `capability_profile.yaml`의 자산 키워드(엔트리·블록코딩·AIDT·코딩교육·JupyterHub 등 제품·기술 토큰) 매칭을 후보 채택의 단독 게이트로 쓴다. 문제 공고 제목은 "AI·디지털 활용 / 수업혁신 / 역량강화 / 연수"라 우리 기술을 직접 호명하지 않아 매칭이 하나도 안 걸린다.

역설적으로 사업유형 분류(`work_types.yaml`)는 `연수`를 교육운영 title 키워드로 이미 갖고 있다. 즉 "연수는 edu 트랙이 담당"임을 분류 규칙은 알지만, 앞단 트리아지가 먼저 탈락시켜 분류까지 가지 못한다. 서울시 건이 뜬 건 그 공고에 우연히 자산 키워드가 있었거나 학교 발주였을 뿐. 상당수 교원연수 공고가 같은 이유로 조용히 누락돼 왔다.

실제 지식파일로 재현:
```
문제공고                triage=탈락  → 분류 못 감
서울시연수(코딩교육)     triage=[entry_block_coding] → 교육운영
```

## 수정
`prepare`의 후보 채택을 합집합으로 변경: 역량 키워드가 걸리거나(제품 호명) 담당 사업유형(config `tracks`의 `work_types` 합집합)으로 분류되면 채택한다. 실제 적합도는 뒷단 LLM 평가의 reuse 축이 거른다. 담당 밖 사업유형(연구 등)은 종전대로 키워드가 걸릴 때만 채택해 스코프 과확대를 막는다.

트레이드오프: 교육운영·행사 등으로 분류되는 전국 공고가 평가에 더 들어와 LLM 배치 수가 소폭 증가한다. 무관·연구·기타는 여전히 제외되므로 폭증은 아니다.

## 테스트
- `test_prepare_admits_work_type_without_keyword`: 제보된 연수 제목이 키워드 미매칭이어도 교육운영으로 채택됨을 재현
- `test_prepare_excludes_off_scope_work_type_without_keyword`: 담당 밖(연구)은 키워드 없으면 제외
- 전체 101 passed / 1 skipped, black 클린