### PR TITLE
fix(edu-bid): near_miss는 보고 문턱 넘는 건만 미래타깃으로 낮춘다

### DIFF
--- a/service/edu_bid/stages.py
+++ b/service/edu_bid/stages.py
@@ -234,14 +234,18 @@ def decide(
     score = sum(float(axes.get(k, 0)) * float(weights.get(k, 0)) for k in weights)
 
     th = knowledge.thresholds
-    if gate_result.status == "near_miss":
-        label = LABEL_FUTURE
-    elif score >= th.get("recommend", 70):
+    if score >= th.get("recommend", 70):
         label = LABEL_RECOMMEND
     elif score >= th.get("review", 50):
         label = LABEL_REVIEW
     else:
         label = LABEL_EXCLUDE
+
+    # 실적제한경쟁(near_miss)은 실적장벽으로 지금은 못 잡는 건 — 적합도가 보고 문턱(추천/검토)
+    # 을 넘는 건만 '미래타깃'으로 낮춰 추적한다. 문턱 미만(무관·저적합)은 실적경쟁이어도 제외해,
+    # 재사용 0짜리 공고가 near_miss 라는 이유만으로 보고되지 않게 한다.
+    if gate_result.status == "near_miss" and label in (LABEL_RECOMMEND, LABEL_REVIEW):
+        label = LABEL_FUTURE
 
     return Decision(
         announcement=ann,

--- a/tests/test_crawl_education_bids.py
+++ b/tests/test_crawl_education_bids.py
@@ -210,12 +210,24 @@ def test_decide_falls_back_to_triage_assets_when_eval_empty():
     assert d.matched_assets == ["codle", "judge"]
 
 
-def test_decide_near_miss_gate_overrides_to_future_target():
+def test_decide_near_miss_demotes_reportable_to_future_target():
+    """실적제한경쟁 + 적합도 높음 → 미래타깃(지금은 실적장벽, 좋은 건이라 추적)."""
     ev = _eval(
         90, 90, 90, 90, quant_barrier="high", wired_risk="high", matched_assets=[]
     )
     d = stages.decide(_ann(), GateResult("near_miss", ["실적"]), ev, [], _KN())
     assert d.label == "미래타깃"
+
+
+def test_decide_near_miss_low_fit_stays_excluded():
+    """실적제한경쟁이어도 적합도가 문턱 미만(무관 건)이면 제외 — 잡음 차단.
+
+    예: 재사용 0인 축제 식당 운영 공고가 실적경쟁이라는 이유만으로 미래타깃으로
+    보고되던 문제(탈춤식당 사례) 재현·수정.
+    """
+    ev = _eval(0, 20, 20, 20, matched_assets=[])  # 0.4*0+0.3*20+0.2*20+0.1*20 = 12점
+    d = stages.decide(_ann(), GateResult("near_miss", ["실적제한경쟁"]), ev, [], _KN())
+    assert d.score == 12.0 and d.label == "제외"
 
 
 # --- format_report ---


### PR DESCRIPTION
## 배경
합집합 채택(#144) 후 교육/연수 채널에 "안동국제탈춤페스티벌 탈춤식당 운영"(행사, 자산 매칭 없음, 재사용 0)이 `미래타깃·11.5점`으로 올라왔다. 완전 무관한 건이라 뜨면 안 된다.

## 원인
`stages.decide`가 실적제한경쟁(`gate.status == near_miss`)이면 종합점수 임계 계산보다 먼저 무조건 `미래타깃`으로 확정한다. 실적원장이 비어 있어(`performance: []`) 실적경쟁=Y 공고는 전부 near_miss가 되므로, 재사용 0짜리 무관 공고도 점수와 무관하게 미래타깃으로 보고된다. #144로 무키워드 행사·교육운영 건이 후보로 들어오면서 이 잡음이 드러났다.

## 수정
점수로 라벨(추천/검토/제외)을 먼저 정하고, near_miss는 그 라벨이 보고 문턱(추천/검토)을 넘는 건만 `미래타깃`으로 낮춘다. 문턱 미만(무관·저적합)은 실적경쟁이어도 `제외`. "지금은 실적장벽으로 못 잡지만 좋은 건"만 미래타깃으로 남는 near_miss 본래 의미를 지키면서 잡음을 없앤다.

## 테스트
- `test_decide_near_miss_demotes_reportable_to_future_target`: 고적합 실적경쟁 → 미래타깃(기존 동작 유지)
- `test_decide_near_miss_low_fit_stays_excluded`: 재사용 0·12점 실적경쟁 → 제외(탈춤식당 사례 재현·수정)
- 전체 102 passed / 1 skipped, black 클린